### PR TITLE
fix: handle 204 No Content responses in API client

### DIFF
--- a/src/components/sources/ActiveToggle.tsx
+++ b/src/components/sources/ActiveToggle.tsx
@@ -123,6 +123,7 @@ export const ActiveToggle = React.memo(function ActiveToggle({
           disabled={isToggling}
           aria-label={`Toggle ${sourceName} active status`}
           aria-describedby={error ? `error-${sourceId}` : undefined}
+          className="data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-gray-300"
         />
         {isToggling && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
       </div>

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -113,6 +113,11 @@ class ApiClient {
         );
       }
 
+      // Handle 204 No Content responses
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
       // Parse successful response
       const data = await response.json();
       return data as T;


### PR DESCRIPTION
  The toggle UI was not updating asynchronously because the API client
  attempted to parse JSON from 204 No Content responses, which have no body.

  - Add check for 204 status before calling response.json()
  - Return undefined for 204 responses to prevent JSON parse errors
  - Toggle now updates UI immediately without requiring page refresh

  Closes #11