### PR TITLE
feat: remove Today quick filter button from DateRangePicker

### DIFF
--- a/src/components/search/DateRangePicker.test.tsx
+++ b/src/components/search/DateRangePicker.test.tsx
@@ -33,10 +33,10 @@ describe('DateRangePicker', () => {
     it('should render quick range buttons', () => {
       render(<DateRangePicker fromDate={null} toDate={null} onChange={vi.fn()} />);
 
-      expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Last 7 Days' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Last 30 Days' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'This Year' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Today' })).not.toBeInTheDocument();
     });
 
     it('should show Clear button when dates are set', () => {
@@ -102,15 +102,6 @@ describe('DateRangePicker', () => {
   });
 
   describe('Quick Range Buttons', () => {
-    it('should set Today range', () => {
-      const onChange = vi.fn();
-      render(<DateRangePicker fromDate={null} toDate={null} onChange={onChange} />);
-
-      fireEvent.click(screen.getByRole('button', { name: 'Today' }));
-
-      expect(onChange).toHaveBeenCalledWith('2025-01-15', '2025-01-15');
-    });
-
     it('should set Last 7 Days range', () => {
       const onChange = vi.fn();
       render(<DateRangePicker fromDate={null} toDate={null} onChange={onChange} />);
@@ -203,7 +194,7 @@ describe('DateRangePicker', () => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
 
       // Then use quick range to clear error
-      fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Last 7 Days' }));
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
   });
@@ -226,7 +217,6 @@ describe('DateRangePicker', () => {
         />
       );
 
-      expect(screen.getByRole('button', { name: 'Today' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Last 7 Days' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Last 30 Days' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'This Year' })).toBeDisabled();

--- a/src/components/search/DateRangePicker.tsx
+++ b/src/components/search/DateRangePicker.tsx
@@ -29,7 +29,7 @@ export interface DateRangePickerProps {
 /**
  * Quick range preset type
  */
-type QuickRange = 'today' | 'week' | 'month' | 'year';
+type QuickRange = 'week' | 'month' | 'year';
 
 /**
  * Calculate quick range dates
@@ -44,9 +44,6 @@ function getQuickRangeDates(range: QuickRange): { from: string; to: string } {
   let from: string;
 
   switch (range) {
-    case 'today':
-      from = to;
-      break;
     case 'week': {
       const weekAgo = new Date(today);
       weekAgo.setDate(today.getDate() - 7);
@@ -184,15 +181,6 @@ export function DateRangePicker({
       )}
 
       <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => handleQuickRange('today')}
-          disabled={disabled}
-        >
-          Today
-        </Button>
         <Button
           type="button"
           variant="outline"


### PR DESCRIPTION
  - Remove 'today' from QuickRange type definition
  - Remove 'today' case from getQuickRangeDates function
  - Remove Today button from UI (only Last 7 Days, Last 30 Days, This Year remain)
  - Update related tests and add negative assertion

  The Today filter often returned 0 results because it filters by
  published_at (original article date), not delivery date. This caused
  a poor user experience, especially for portfolio demonstrations.

  Closes #35