### PR TITLE
chore: 429 注釈修正(backend #77)への生成型追随

### DIFF
--- a/src/types/generated/api.d.ts
+++ b/src/types/generated/api.d.ts
@@ -314,7 +314,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                        "application/json": string;
                     };
                 };
                 /** @description Server error */
@@ -762,7 +762,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                        "application/json": string;
                     };
                 };
                 /** @description Server error */


### PR DESCRIPTION
backend PR #77 の CodeRabbit 対応で、rate-limit ミドルウェア由来の 429(/articles/search・/sources/search)の swag 注釈が実ワイヤ形式(text/plain)どおり `{string}` に是正されました。本 PR はその生成型追随(2行)です。

- ランタイム影響なし(エラーパースは生成型に依存しない実装)
- `npx tsc --noEmit` 通過
- backend #77 とどちらが先でも問題ありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)