### PR TITLE
Phase 3: 学習ループの管理画面(採点・理解トラッカー・書籍管理)

### DIFF
--- a/src/app/(protected)/learning/books/page.tsx
+++ b/src/app/(protected)/learning/books/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { ArrowLeft, BookOpen } from 'lucide-react';
+import { PageHeader } from '@/components/common/PageHeader';
+import { ErrorMessage } from '@/components/common/ErrorMessage';
+import { EmptyState } from '@/components/common/EmptyState';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { BookCard } from '@/components/learning/BookCard';
+import { useLearningBooks, useActivateBook, useDeactivateBook } from '@/hooks/useLearning';
+import type { LearningBook } from '@/types/api';
+
+/**
+ * Learning — book management (D-20)
+ *
+ * Lists ingested books with progress, and lets the user pick the single
+ * in-progress book. Activating a book swaps out whatever was active
+ * (backend enforces at-most-one-active); pausing keeps the cursor;
+ * re-activating a finished book restarts it. A plain list + toggle is all
+ * this needs.
+ */
+export default function LearningBooksPage() {
+  const { books, isLoading, error, refetch } = useLearningBooks();
+  const { mutateAsync: activate, isPending: isActivating } = useActivateBook();
+  const { mutateAsync: deactivate, isPending: isDeactivating } = useDeactivateBook();
+
+  const busy = isActivating || isDeactivating;
+
+  const handleActivate = React.useCallback(
+    async (book: LearningBook) => {
+      if (busy) {
+        return;
+      }
+      try {
+        await activate(book.id);
+      } catch {
+        // Error surfaced via the hook; the list re-syncs on the next fetch.
+      }
+    },
+    [activate, busy]
+  );
+
+  const handleDeactivate = React.useCallback(
+    async (book: LearningBook) => {
+      if (busy) {
+        return;
+      }
+      try {
+        await deactivate(book.id);
+      } catch {
+        // Deactivate is idempotent; a retry is always safe.
+      }
+    },
+    [deactivate, busy]
+  );
+
+  const activeBook = books.find((b) => b.review_status === 'active');
+
+  return (
+    <div className="container py-8">
+      <div className="mb-2">
+        <Button asChild variant="ghost" size="sm" className="text-muted-foreground">
+          <Link href="/learning">
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Review
+          </Link>
+        </Button>
+      </div>
+
+      <PageHeader
+        title="Books"
+        description={
+          activeBook
+            ? `進行中: ${activeBook.title}`
+            : '書籍の復習コーナーで進める1冊を選ぶ(同時に1冊)'
+        }
+      />
+
+      {error && (
+        <div className="mb-6">
+          <ErrorMessage error={error} onRetry={refetch} />
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 w-full rounded-lg" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !error && books.length === 0 && (
+        <EmptyState
+          title="取り込み済みの書籍はありません"
+          description="書籍の取り込み(ingest)は Mac 側の CLI で行います。取り込むとここに並びます。"
+          icon={<BookOpen className="h-12 w-12" />}
+        />
+      )}
+
+      {!isLoading && !error && books.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2" role="list">
+          {books.map((book) => (
+            <BookCard
+              key={book.id}
+              book={book}
+              onActivate={handleActivate}
+              onDeactivate={handleDeactivate}
+              disabled={busy}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/learning/items/page.tsx
+++ b/src/app/(protected)/learning/items/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { ArrowLeft, ListChecks } from 'lucide-react';
+import { PageHeader } from '@/components/common/PageHeader';
+import { ErrorMessage } from '@/components/common/ErrorMessage';
+import { EmptyState } from '@/components/common/EmptyState';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { LearningItemCard } from '@/components/learning/LearningItemCard';
+import { useLearningItems, useRetireItem } from '@/hooks/useLearning';
+import type { LearningItem, LearningItemStatus } from '@/types/api';
+
+const TABS: ReadonlyArray<{ value: LearningItemStatus; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'retired', label: 'Graduated' },
+];
+
+/**
+ * Learning — tracker (理解トラッカー)
+ *
+ * Active tab: current items with stage, next scheduled date, and history.
+ * Graduated tab: archived / completed items (read-only).
+ *
+ * A plain, quiet list: overdue items are never colored or counted (§8.2).
+ */
+export default function LearningItemsPage() {
+  const [status, setStatus] = React.useState<LearningItemStatus>('active');
+  const { items, isLoading, error, refetch } = useLearningItems(status);
+  const { mutateAsync: retire, isPending: isRetiring } = useRetireItem();
+
+  const handleRetire = React.useCallback(
+    async (item: LearningItem) => {
+      if (isRetiring) {
+        return;
+      }
+      try {
+        await retire(item.id);
+      } catch {
+        // Surfaced via the hook's error state on the next render if needed;
+        // retire is idempotent, so a retry is always safe.
+      }
+    },
+    [retire, isRetiring]
+  );
+
+  return (
+    <div className="container py-8">
+      <div className="mb-2">
+        <Button asChild variant="ghost" size="sm" className="text-muted-foreground">
+          <Link href="/learning">
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Review
+          </Link>
+        </Button>
+      </div>
+
+      <PageHeader title="Tracker" description="学習項目の定着ぐあいを見る" />
+
+      {/* Status tabs */}
+      <div
+        className="mb-6 inline-flex rounded-lg border border-border/60 bg-background/40 p-1"
+        role="tablist"
+        aria-label="Item status"
+      >
+        {TABS.map((tab) => {
+          const isActive = status === tab.value;
+          return (
+            <button
+              key={tab.value}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setStatus(tab.value)}
+              className={cn(
+                'rounded-md px-4 py-1.5 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <div className="mb-6">
+          <ErrorMessage error={error} onRetry={refetch} />
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-40 w-full rounded-lg" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !error && items.length === 0 && (
+        <EmptyState
+          title={status === 'active' ? 'まだ学習項目はありません' : '卒業した項目はまだありません'}
+          description={
+            status === 'active'
+              ? '番組で出題された内容が、ここに項目として貯まっていきます。'
+              : 'ラダーを完走した項目や、手動でしまった項目がここに並びます。'
+          }
+          icon={<ListChecks className="h-12 w-12" />}
+        />
+      )}
+
+      {!isLoading && !error && items.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2" role="list">
+          {items.map((item) => (
+            <LearningItemCard
+              key={item.id}
+              item={item}
+              onRetire={status === 'active' ? handleRetire : undefined}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/learning/page.tsx
+++ b/src/app/(protected)/learning/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { ListChecks, BookOpen } from 'lucide-react';
+import { PageHeader } from '@/components/common/PageHeader';
+import { ErrorMessage } from '@/components/common/ErrorMessage';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { GradingDeck } from '@/components/learning/GradingDeck';
+import { usePendingReviews, useGradeReview } from '@/hooks/useLearning';
+
+/**
+ * Learning — grading page (mobile-first, the primary flow)
+ *
+ * Shows one pending review at a time: concept + question, tap to reveal the
+ * answer, then ○ △ × to grade. Grading is optimistic so a batch of reviews
+ * clears in a few quiet taps during細切れ時間.
+ *
+ * Deliberately calm: no counters, no overdue warnings, no streaks. An empty
+ * queue is a good day, shown warmly ("今日は採点するものがありません").
+ */
+export default function LearningPage() {
+  const { reviews, isLoading, error, refetch } = usePendingReviews();
+  const { grade } = useGradeReview();
+
+  return (
+    <div className="container py-8">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <PageHeader title="Review" description="番組で出題された内容をふりかえる" />
+        <div className="flex flex-shrink-0 gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link href="/learning/items">
+              <ListChecks className="mr-1 h-4 w-4" />
+              Tracker
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/learning/books">
+              <BookOpen className="mr-1 h-4 w-4" />
+              Books
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-6">
+          <ErrorMessage error={error} onRetry={refetch} />
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="mx-auto w-full max-w-xl">
+          <Skeleton className="h-64 w-full rounded-lg" />
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <GradingDeck
+          reviews={reviews}
+          onGrade={(logId, result) => grade({ logId, result })}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/learning/page.tsx
+++ b/src/app/(protected)/learning/page.tsx
@@ -57,10 +57,7 @@ export default function LearningPage() {
       )}
 
       {!isLoading && !error && (
-        <GradingDeck
-          reviews={reviews}
-          onGrade={(logId, result) => grade({ logId, result })}
-        />
+        <GradingDeck reviews={reviews} onGrade={(logId, result) => grade({ logId, result })} />
       )}
     </div>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ const mainNavigation = [
   { name: 'Sources', href: '/sources' },
   { name: 'Friends', href: '/subscribers' },
   { name: 'Access Logs', href: '/access-logs' },
+  { name: 'Review', href: '/learning' },
 ];
 
 const legalNavigation = [

--- a/src/components/learning/BookCard.stories.tsx
+++ b/src/components/learning/BookCard.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { BookCard } from './BookCard';
+import type { LearningBook } from '@/types/api';
+
+/**
+ * BookCard Component
+ *
+ * One ingested book in the book manager (D-20): title, review status,
+ * progress, and a single activate / deactivate toggle. At most one book is
+ * active at a time; activating another swaps it.
+ */
+const meta = {
+  title: 'Learning/BookCard',
+  component: BookCard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof BookCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const base: LearningBook = {
+  id: 7,
+  title: 'リーダブルコード',
+  review_status: 'idle',
+  review_cursor: 45,
+  total_chunks: 180,
+};
+
+/**
+ * The in-progress book (offers Pause).
+ */
+export const Active: Story = {
+  args: {
+    book: { ...base, review_status: 'active', review_cursor: 90 },
+    onActivate: () => {},
+    onDeactivate: () => {},
+  },
+};
+
+/**
+ * A paused / idle book (offers Activate).
+ */
+export const Idle: Story = {
+  args: {
+    book: base,
+    onActivate: () => {},
+    onDeactivate: () => {},
+  },
+};
+
+/**
+ * A finished book (offers Re-read, which restarts from the beginning).
+ */
+export const Finished: Story = {
+  args: {
+    book: { ...base, review_status: 'finished', review_cursor: 180 },
+    onActivate: () => {},
+    onDeactivate: () => {},
+  },
+};

--- a/src/components/learning/BookCard.test.tsx
+++ b/src/components/learning/BookCard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BookCard } from './BookCard';
+import { LEARNING_TEST_IDS } from '@/constants/learning';
+import type { LearningBook } from '@/types/api';
+
+const base: LearningBook = {
+  id: 7,
+  title: 'リーダブルコード',
+  review_status: 'idle',
+  review_cursor: 45,
+  total_chunks: 180,
+};
+
+describe('BookCard', () => {
+  it('shows title and progress percent', () => {
+    render(<BookCard book={base} onActivate={vi.fn()} onDeactivate={vi.fn()} />);
+
+    expect(screen.getByText('リーダブルコード')).toBeInTheDocument();
+    // 45 / 180 = 25%
+    expect(screen.getByText(/45 \/ 180 \(25%\)/)).toBeInTheDocument();
+  });
+
+  it('offers Activate for an idle book and calls onActivate', async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+    render(<BookCard book={base} onActivate={onActivate} onDeactivate={vi.fn()} />);
+
+    const toggle = screen.getByTestId(LEARNING_TEST_IDS.BOOK_TOGGLE);
+    expect(toggle).toHaveTextContent('Activate');
+    await user.click(toggle);
+    expect(onActivate).toHaveBeenCalledWith(base);
+  });
+
+  it('offers Pause for an active book and calls onDeactivate', async () => {
+    const user = userEvent.setup();
+    const onDeactivate = vi.fn();
+    render(
+      <BookCard
+        book={{ ...base, review_status: 'active' }}
+        onActivate={vi.fn()}
+        onDeactivate={onDeactivate}
+      />
+    );
+
+    const toggle = screen.getByTestId(LEARNING_TEST_IDS.BOOK_TOGGLE);
+    expect(toggle).toHaveTextContent('Pause');
+    await user.click(toggle);
+    expect(onDeactivate).toHaveBeenCalled();
+  });
+
+  it('labels a finished book as Re-read', () => {
+    render(
+      <BookCard
+        book={{ ...base, review_status: 'finished', review_cursor: 180 }}
+        onActivate={vi.fn()}
+        onDeactivate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId(LEARNING_TEST_IDS.BOOK_TOGGLE)).toHaveTextContent('Re-read');
+    expect(screen.getByText(/180 \/ 180 \(100%\)/)).toBeInTheDocument();
+  });
+
+  it('handles zero total chunks without dividing by zero', () => {
+    render(
+      <BookCard
+        book={{ ...base, review_cursor: 0, total_chunks: 0 }}
+        onActivate={vi.fn()}
+        onDeactivate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/0 \/ 0 \(0%\)/)).toBeInTheDocument();
+  });
+});

--- a/src/components/learning/BookCard.tsx
+++ b/src/components/learning/BookCard.tsx
@@ -1,0 +1,135 @@
+/**
+ * BookCard Component
+ *
+ * One ingested book in the book manager (D-20). Shows the title, review
+ * status, and progress (review_cursor / total_chunks), with a single
+ * activate / deactivate toggle.
+ *
+ * At most one book is active at a time; activating another book is an
+ * implicit swap handled by the backend. Activating a finished book restarts
+ * the read — no special confirmation, just the activate button (§8.2).
+ */
+'use client';
+
+import * as React from 'react';
+import { BookOpen, Play, Pause } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { BOOK_STATUS_LABELS, LEARNING_TEST_IDS } from '@/constants/learning';
+import type { LearningBook, BookReviewStatus } from '@/types/api';
+
+interface BookCardProps {
+  /** The book to display */
+  book: LearningBook;
+  /** Activate this book (set as the single in-progress book) */
+  onActivate: (book: LearningBook) => void;
+  /** Deactivate this book (pause, keep cursor) */
+  onDeactivate: (book: LearningBook) => void;
+  /** Disable actions while a book mutation is in flight */
+  disabled?: boolean;
+}
+
+const STATUS_VARIANT: Record<BookReviewStatus, 'success' | 'secondary' | 'default'> = {
+  active: 'success',
+  finished: 'default',
+  idle: 'secondary',
+};
+
+function progressPercent(cursor: number, total: number): number {
+  if (total <= 0) {
+    return 0;
+  }
+  return Math.min(100, Math.round((cursor / total) * 100));
+}
+
+/**
+ * BookCard — title, progress bar, and an activate/deactivate toggle.
+ */
+export const BookCard = React.memo(function BookCard({
+  book,
+  onActivate,
+  onDeactivate,
+  disabled = false,
+}: BookCardProps) {
+  const status = (book.review_status ?? 'idle') as BookReviewStatus;
+  const isActive = status === 'active';
+  const percent = progressPercent(book.review_cursor, book.total_chunks);
+
+  return (
+    <Card
+      className={cn('flex flex-col', isActive && 'border-primary/40')}
+      data-testid={LEARNING_TEST_IDS.BOOK}
+      role="listitem"
+      aria-label={`Book: ${book.title}`}
+    >
+      <CardContent className="flex flex-col gap-4 p-5">
+        {/* Title + status */}
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/30 bg-primary/10">
+            <BookOpen className="h-4 w-4 text-primary" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-base font-semibold leading-snug text-foreground">{book.title}</h3>
+            <Badge variant={STATUS_VARIANT[status]} className="mt-1">
+              {BOOK_STATUS_LABELS[status] ?? status}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Progress */}
+        <div>
+          <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+            <span>Progress</span>
+            <span>
+              {book.review_cursor} / {book.total_chunks} ({percent}%)
+            </span>
+          </div>
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${book.title} progress`}
+          >
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Toggle */}
+        <div className="flex justify-end">
+          {isActive ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onDeactivate(book)}
+              disabled={disabled}
+              data-testid={LEARNING_TEST_IDS.BOOK_TOGGLE}
+              aria-label={`Pause ${book.title}`}
+            >
+              <Pause className="mr-1 h-4 w-4" />
+              Pause
+            </Button>
+          ) : (
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => onActivate(book)}
+              disabled={disabled}
+              data-testid={LEARNING_TEST_IDS.BOOK_TOGGLE}
+              aria-label={`Activate ${book.title}`}
+            >
+              <Play className="mr-1 h-4 w-4" />
+              {status === 'finished' ? 'Re-read' : 'Activate'}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+});

--- a/src/components/learning/GradingDeck.stories.tsx
+++ b/src/components/learning/GradingDeck.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { GradingDeck } from './GradingDeck';
+import type { PendingReview } from '@/types/api';
+
+/**
+ * GradingDeck Component
+ *
+ * The one-card-at-a-time grading flow. Grading advances instantly
+ * (optimistic); an empty deck is a good day, shown warmly.
+ */
+const meta = {
+  title: 'Learning/GradingDeck',
+  component: GradingDeck,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof GradingDeck>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const reviews: PendingReview[] = [
+  {
+    log_id: 1,
+    item_id: 10,
+    asked_on: '2026-07-07',
+    concept: 'goroutine リーク検出',
+    question: 'goroutine リークはまず何を見て切り分けますか?',
+    answer: 'pprof の goroutine プロファイルを2回取り、数の単調増加を見る。',
+  },
+  {
+    log_id: 2,
+    item_id: 11,
+    asked_on: '2026-07-07',
+    concept: 'context のキャンセル伝播',
+    question: 'context.WithCancel の cancel を呼び忘れると何が起きますか?',
+    answer: 'context がリークし、紐づく goroutine が終了せず残ることがある。',
+  },
+];
+
+/**
+ * A deck with reviews to grade.
+ */
+export const WithReviews: Story = {
+  args: {
+    reviews,
+    onGrade: () => {},
+  },
+};
+
+/**
+ * Nothing to grade — the calm empty state.
+ */
+export const Empty: Story = {
+  args: {
+    reviews: [],
+    onGrade: () => {},
+  },
+};

--- a/src/components/learning/GradingDeck.test.tsx
+++ b/src/components/learning/GradingDeck.test.tsx
@@ -6,7 +6,14 @@ import { LEARNING_TEST_IDS } from '@/constants/learning';
 import type { PendingReview } from '@/types/api';
 
 const reviews: PendingReview[] = [
-  { log_id: 1, item_id: 10, asked_on: '2026-07-07', concept: 'First', question: 'q1', answer: 'a1' },
+  {
+    log_id: 1,
+    item_id: 10,
+    asked_on: '2026-07-07',
+    concept: 'First',
+    question: 'q1',
+    answer: 'a1',
+  },
   {
     log_id: 2,
     item_id: 11,

--- a/src/components/learning/GradingDeck.test.tsx
+++ b/src/components/learning/GradingDeck.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GradingDeck } from './GradingDeck';
+import { LEARNING_TEST_IDS } from '@/constants/learning';
+import type { PendingReview } from '@/types/api';
+
+const reviews: PendingReview[] = [
+  { log_id: 1, item_id: 10, asked_on: '2026-07-07', concept: 'First', question: 'q1', answer: 'a1' },
+  {
+    log_id: 2,
+    item_id: 11,
+    asked_on: '2026-07-07',
+    concept: 'Second',
+    question: 'q2',
+    answer: 'a2',
+  },
+];
+
+describe('GradingDeck', () => {
+  it('renders the friendly empty state when there is nothing to grade', () => {
+    render(<GradingDeck reviews={[]} onGrade={vi.fn()} />);
+
+    expect(screen.getByTestId(LEARNING_TEST_IDS.EMPTY)).toBeInTheDocument();
+    expect(screen.getByText('今日は採点するものがありません')).toBeInTheDocument();
+  });
+
+  it('shows the oldest card first', () => {
+    render(<GradingDeck reviews={reviews} onGrade={vi.fn()} />);
+
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.queryByText('Second')).not.toBeInTheDocument();
+  });
+
+  it('advances to the next card immediately after grading (optimistic)', async () => {
+    const user = userEvent.setup();
+    const onGrade = vi.fn();
+    render(<GradingDeck reviews={reviews} onGrade={onGrade} />);
+
+    // Reveal + grade the first card.
+    await user.click(screen.getByTestId(LEARNING_TEST_IDS.REVEAL_BUTTON));
+    await user.click(screen.getByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-good`));
+
+    expect(onGrade).toHaveBeenCalledWith(1, 'good');
+    // Next card is shown, and its answer starts hidden again.
+    expect(screen.getByText('Second')).toBeInTheDocument();
+    expect(screen.queryByTestId(LEARNING_TEST_IDS.ANSWER)).not.toBeInTheDocument();
+  });
+
+  it('reaches the empty state after the last card is graded', async () => {
+    const user = userEvent.setup();
+    render(<GradingDeck reviews={reviews.slice(0, 1)} onGrade={vi.fn()} />);
+
+    await user.click(screen.getByTestId(LEARNING_TEST_IDS.REVEAL_BUTTON));
+    await user.click(screen.getByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-fuzzy`));
+
+    expect(screen.getByTestId(LEARNING_TEST_IDS.EMPTY)).toBeInTheDocument();
+  });
+});

--- a/src/components/learning/GradingDeck.tsx
+++ b/src/components/learning/GradingDeck.tsx
@@ -1,0 +1,77 @@
+/**
+ * GradingDeck Component
+ *
+ * Drives the one-card-at-a-time grading flow. Progression is local and
+ * instant: tapping a grade adds the card's log_id to a "processed" set so
+ * the next card appears immediately, while the mutation runs in the
+ * background (optimistic update, §8.2). A 409 (already graded elsewhere) is
+ * absorbed by the mutation and the card stays skipped — no interruption.
+ *
+ * The visible deck = fetched reviews minus locally-processed ones, so the
+ * deck stays stable even if the pending cache shifts underneath.
+ */
+'use client';
+
+import * as React from 'react';
+import { CheckCircle2 } from 'lucide-react';
+import { EmptyState } from '@/components/common/EmptyState';
+import { ReviewCard } from '@/components/learning/ReviewCard';
+import { LEARNING_TEST_IDS } from '@/constants/learning';
+import type { PendingReview, GradeResult } from '@/types/api';
+
+interface GradingDeckProps {
+  /** The pending reviews fetched from the server (oldest first) */
+  reviews: PendingReview[];
+  /** Fire the grade mutation for a review */
+  onGrade: (logId: number, result: GradeResult) => void;
+}
+
+/**
+ * GradingDeck — shows the oldest un-processed card; advances on grade.
+ */
+export function GradingDeck({ reviews, onGrade }: GradingDeckProps) {
+  // log_ids graded in this session. Drives instant advance and keeps the
+  // deck stable regardless of cache churn.
+  const [processed, setProcessed] = React.useState<ReadonlySet<number>>(() => new Set());
+
+  const deck = React.useMemo(
+    () => reviews.filter((r) => !processed.has(r.log_id)),
+    [reviews, processed]
+  );
+
+  const current = deck[0];
+
+  const handleGrade = React.useCallback(
+    (result: GradeResult) => {
+      if (!current) {
+        return;
+      }
+      const logId = current.log_id;
+      // Advance the UI first (optimistic), then fire the mutation.
+      setProcessed((prev) => {
+        const next = new Set(prev);
+        next.add(logId);
+        return next;
+      });
+      onGrade(logId, result);
+    },
+    [current, onGrade]
+  );
+
+  if (!current) {
+    return (
+      <div data-testid={LEARNING_TEST_IDS.EMPTY}>
+        <EmptyState
+          title="今日は採点するものがありません"
+          description="また番組を聴いたら、ここに復習が並びます。"
+          icon={<CheckCircle2 className="h-12 w-12 text-primary" />}
+        />
+      </div>
+    );
+  }
+
+  return (
+    // key on log_id resets the card's reveal state for each new card.
+    <ReviewCard key={current.log_id} review={current} onGrade={handleGrade} />
+  );
+}

--- a/src/components/learning/LearningItemCard.stories.tsx
+++ b/src/components/learning/LearningItemCard.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { LearningItemCard } from './LearningItemCard';
+import type { LearningItem } from '@/types/api';
+
+/**
+ * LearningItemCard Component
+ *
+ * One row in the理解トラッカー: concept, kind badge, stage, next scheduled
+ * date, and a compact history. The due date is shown plainly — no overdue
+ * warning color, no "N days late" framing.
+ */
+const meta = {
+  title: 'Learning/LearningItemCard',
+  component: LearningItemCard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LearningItemCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const active: LearningItem = {
+  id: 3,
+  kind: 'article',
+  article_id: 42,
+  book_id: null,
+  concept: 'goroutine リーク検出',
+  question: 'q',
+  answer: 'a',
+  provider: 'gemini',
+  stage: 1,
+  due_on: '2026-07-14',
+  retired_at: null,
+  created_at: '2026-07-07T00:00:00Z',
+  times_asked: 2,
+  last_result: 'good',
+  last_asked_on: '2026-07-07',
+};
+
+/**
+ * Active article item with history.
+ */
+export const Active: Story = {
+  args: {
+    item: active,
+    onRetire: () => {},
+  },
+};
+
+/**
+ * Book-derived item, forgotten last time (pulled back to stage 0).
+ */
+export const BookForgot: Story = {
+  args: {
+    item: {
+      ...active,
+      id: 4,
+      kind: 'book',
+      article_id: null,
+      book_id: 7,
+      concept: '名前は意図を語る',
+      provider: 'ollama',
+      stage: 0,
+      due_on: '2026-07-08',
+      last_result: 'forgot',
+    },
+    onRetire: () => {},
+  },
+};
+
+/**
+ * Graduated (retired) item — read-only, no next date, no retire button.
+ */
+export const Graduated: Story = {
+  args: {
+    item: {
+      ...active,
+      id: 5,
+      stage: 3,
+      retired_at: '2026-08-01T00:00:00Z',
+      times_asked: 4,
+    },
+  },
+};

--- a/src/components/learning/LearningItemCard.test.tsx
+++ b/src/components/learning/LearningItemCard.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LearningItemCard } from './LearningItemCard';
+import { LEARNING_TEST_IDS } from '@/constants/learning';
+import type { LearningItem } from '@/types/api';
+
+const activeItem: LearningItem = {
+  id: 3,
+  kind: 'article',
+  article_id: 42,
+  book_id: null,
+  concept: 'goroutine リーク検出',
+  question: 'q',
+  answer: 'a',
+  provider: 'gemini',
+  stage: 1,
+  due_on: '2026-07-14',
+  retired_at: null,
+  created_at: '2026-07-07T00:00:00Z',
+  times_asked: 2,
+  last_result: 'good',
+  last_asked_on: '2026-07-07',
+};
+
+describe('LearningItemCard', () => {
+  it('renders concept, stage, next date and history for an active item', () => {
+    render(<LearningItemCard item={activeItem} onRetire={vi.fn()} />);
+
+    expect(screen.getByText('goroutine リーク検出')).toBeInTheDocument();
+    expect(screen.getByText('Stage 1')).toBeInTheDocument();
+    expect(screen.getByText('2026-07-14')).toBeInTheDocument();
+    expect(screen.getByText('2×')).toBeInTheDocument();
+    expect(screen.getByText('○ わかった')).toBeInTheDocument();
+    expect(screen.getByText('Article')).toBeInTheDocument();
+  });
+
+  it('calls onRetire when the retire button is tapped', async () => {
+    const user = userEvent.setup();
+    const onRetire = vi.fn();
+    render(<LearningItemCard item={activeItem} onRetire={onRetire} />);
+
+    await user.click(screen.getByTestId(LEARNING_TEST_IDS.RETIRE_BUTTON));
+    expect(onRetire).toHaveBeenCalledWith(activeItem);
+  });
+
+  it('hides the retire button and the next date for a retired item', () => {
+    render(
+      <LearningItemCard
+        item={{ ...activeItem, retired_at: '2026-08-01T00:00:00Z' }}
+        onRetire={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId(LEARNING_TEST_IDS.RETIRE_BUTTON)).not.toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+  });
+
+  it('shows a book badge for book items', () => {
+    render(
+      <LearningItemCard
+        item={{ ...activeItem, kind: 'book', article_id: null, book_id: 7 }}
+        onRetire={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Book')).toBeInTheDocument();
+  });
+});

--- a/src/components/learning/LearningItemCard.tsx
+++ b/src/components/learning/LearningItemCard.tsx
@@ -1,0 +1,119 @@
+/**
+ * LearningItemCard Component
+ *
+ * One row in the理解トラッカー. Shows the concept, a kind badge
+ * (article / book), the spaced-repetition stage, the next scheduled date,
+ * and a compact history summary (times asked + last result). Active items
+ * carry a manual retire action ("もう追わなくていい").
+ *
+ * Calm by design: the due date is shown plainly with NO overdue warning
+ * color, and there is no "N days late" framing (§8.2 禁止事項).
+ */
+'use client';
+
+import * as React from 'react';
+import { Archive, FileText, BookOpen } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { formatRelativeTime } from '@/lib/utils/formatDate';
+import { LEARNING_TEST_IDS } from '@/constants/learning';
+import type { LearningItem } from '@/types/api';
+
+interface LearningItemCardProps {
+  /** The learning item to display */
+  item: LearningItem;
+  /** Called when the retire button is tapped (active items only) */
+  onRetire?: (item: LearningItem) => void;
+}
+
+const RESULT_LABEL: Record<string, string> = {
+  good: '○ わかった',
+  fuzzy: '△ あいまい',
+  forgot: '× 忘れた',
+  auto: '自動前進',
+};
+
+/**
+ * LearningItemCard — a single tracked item.
+ */
+export const LearningItemCard = React.memo(function LearningItemCard({
+  item,
+  onRetire,
+}: LearningItemCardProps) {
+  const isBook = item.kind === 'book';
+  const isRetired = item.retired_at !== null;
+
+  return (
+    <Card
+      className={cn('flex flex-col', isRetired && 'opacity-70')}
+      data-testid={LEARNING_TEST_IDS.ITEM}
+      role="listitem"
+      aria-label={`Item: ${item.concept}`}
+    >
+      <CardContent className="flex flex-col gap-3 p-5">
+        {/* Concept + kind badge */}
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/30 bg-primary/10">
+            {isBook ? (
+              <BookOpen className="h-4 w-4 text-primary" aria-hidden="true" />
+            ) : (
+              <FileText className="h-4 w-4 text-primary" aria-hidden="true" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-base font-semibold leading-snug text-foreground">{item.concept}</h3>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <Badge variant="outline">{isBook ? 'Book' : 'Article'}</Badge>
+              <Badge variant="secondary">Stage {item.stage}</Badge>
+            </div>
+          </div>
+        </div>
+
+        {/* Meta: schedule + history */}
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+          {!isRetired && (
+            <div>
+              <dt className="text-xs text-muted-foreground">Next</dt>
+              <dd className="text-foreground">{item.due_on || '—'}</dd>
+            </div>
+          )}
+          <div>
+            <dt className="text-xs text-muted-foreground">Asked</dt>
+            <dd className="text-foreground">{item.times_asked}×</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Last</dt>
+            <dd className="text-foreground">
+              {item.last_result ? (RESULT_LABEL[item.last_result] ?? item.last_result) : '—'}
+            </dd>
+          </div>
+          {isRetired && item.retired_at && (
+            <div>
+              <dt className="text-xs text-muted-foreground">Retired</dt>
+              <dd className="text-foreground">{formatRelativeTime(item.retired_at)}</dd>
+            </div>
+          )}
+        </dl>
+
+        {/* Retire action (active only) */}
+        {!isRetired && onRetire && (
+          <div className="flex justify-end pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={() => onRetire(item)}
+              data-testid={LEARNING_TEST_IDS.RETIRE_BUTTON}
+              aria-label={`Retire item: ${item.concept}`}
+            >
+              <Archive className="mr-1 h-4 w-4" />
+              Retire
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+});

--- a/src/components/learning/ReviewCard.stories.tsx
+++ b/src/components/learning/ReviewCard.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ReviewCard } from './ReviewCard';
+import type { PendingReview } from '@/types/api';
+
+/**
+ * ReviewCard Component
+ *
+ * A single review on the grading page (mobile-first): concept + question,
+ * tap to reveal the answer, then ○ △ × to grade. No counters, no overdue
+ * warnings — grading is a quiet, frictionless flow.
+ */
+const meta = {
+  title: 'Learning/ReviewCard',
+  component: ReviewCard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ReviewCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const review: PendingReview = {
+  log_id: 12,
+  item_id: 3,
+  asked_on: '2026-07-07',
+  concept: 'goroutine リーク検出',
+  question:
+    'goroutine リークが疑われるとき、まず何を見て切り分けますか?ラジオで触れた方法を思い出してみましょう。',
+  answer:
+    'pprof の goroutine プロファイルを取り、時間をおいて2回比較して数が単調増加していないかを見ます。増えていれば、どのスタックで滞留しているかがそのまま原因箇所です。',
+};
+
+/**
+ * Question shown, answer hidden until tapped.
+ */
+export const Question: Story = {
+  args: {
+    review,
+    onGrade: () => {},
+  },
+};
+
+/**
+ * A short book-derived review.
+ */
+export const BookReview: Story = {
+  args: {
+    review: {
+      ...review,
+      log_id: 20,
+      concept: '名前は意図を語る',
+      question: '良い変数名の条件を、本で挙げられていた観点から一つ挙げてください。',
+      answer: '「誤解されない」こと。読み手が別の意味に取れる名前は、短くても悪い名前です。',
+    },
+    onGrade: () => {},
+  },
+};

--- a/src/components/learning/ReviewCard.test.tsx
+++ b/src/components/learning/ReviewCard.test.tsx
@@ -26,9 +26,7 @@ describe('ReviewCard', () => {
   it('does not show grade buttons before the answer is revealed', () => {
     render(<ReviewCard review={review} onGrade={vi.fn()} />);
 
-    expect(
-      screen.queryByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-good`)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-good`)).not.toBeInTheDocument();
   });
 
   it('reveals the answer and grade buttons on tap', async () => {

--- a/src/components/learning/ReviewCard.test.tsx
+++ b/src/components/learning/ReviewCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReviewCard } from './ReviewCard';
+import { LEARNING_TEST_IDS } from '@/constants/learning';
+import type { PendingReview } from '@/types/api';
+
+const review: PendingReview = {
+  log_id: 12,
+  item_id: 3,
+  asked_on: '2026-07-07',
+  concept: 'goroutine リーク検出',
+  question: 'goroutine リークはどう検出する?',
+  answer: 'pprof の goroutine プロファイルで数の増加を見る。',
+};
+
+describe('ReviewCard', () => {
+  it('shows the concept and question but hides the answer initially', () => {
+    render(<ReviewCard review={review} onGrade={vi.fn()} />);
+
+    expect(screen.getByText(review.concept)).toBeInTheDocument();
+    expect(screen.getByText(review.question)).toBeInTheDocument();
+    expect(screen.queryByTestId(LEARNING_TEST_IDS.ANSWER)).not.toBeInTheDocument();
+  });
+
+  it('does not show grade buttons before the answer is revealed', () => {
+    render(<ReviewCard review={review} onGrade={vi.fn()} />);
+
+    expect(
+      screen.queryByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-good`)
+    ).not.toBeInTheDocument();
+  });
+
+  it('reveals the answer and grade buttons on tap', async () => {
+    const user = userEvent.setup();
+    render(<ReviewCard review={review} onGrade={vi.fn()} />);
+
+    await user.click(screen.getByTestId(LEARNING_TEST_IDS.REVEAL_BUTTON));
+
+    expect(screen.getByTestId(LEARNING_TEST_IDS.ANSWER)).toHaveTextContent(review.answer);
+    expect(screen.getByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-good`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-fuzzy`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-forgot`)).toBeInTheDocument();
+  });
+
+  it('calls onGrade with the chosen result', async () => {
+    const user = userEvent.setup();
+    const onGrade = vi.fn();
+    render(<ReviewCard review={review} onGrade={onGrade} />);
+
+    await user.click(screen.getByTestId(LEARNING_TEST_IDS.REVEAL_BUTTON));
+    await user.click(screen.getByTestId(`${LEARNING_TEST_IDS.GRADE_BUTTON}-forgot`));
+
+    expect(onGrade).toHaveBeenCalledWith('forgot');
+  });
+});

--- a/src/components/learning/ReviewCard.tsx
+++ b/src/components/learning/ReviewCard.tsx
@@ -1,0 +1,116 @@
+/**
+ * ReviewCard Component
+ *
+ * A single review shown on the grading page: concept + question, tap to
+ * reveal the answer, then grade with the big ○ △ × buttons. Built for the
+ * phone: one card at a time, large touch targets, thumb-reachable actions.
+ *
+ * No progress counter, no "N remaining" badge — grading is a quiet,
+ * frictionless flow, never a backlog to clear (§2 Out, §8.2 禁止事項).
+ */
+'use client';
+
+import * as React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { GRADE_OPTIONS, LEARNING_TEST_IDS } from '@/constants/learning';
+import type { PendingReview, GradeResult } from '@/types/api';
+
+interface ReviewCardProps {
+  /** The pending review to display */
+  review: PendingReview;
+  /** Called with the chosen result when a grade button is tapped */
+  onGrade: (result: GradeResult) => void;
+}
+
+const GRADE_BUTTON_STYLES: Record<GradeResult, string> = {
+  good: 'border-[#00ffff]/50 bg-[#a0ffff]/10 text-[#a0ffff] hover:bg-[#a0ffff]/20 hover:shadow-[0_0_12px_#00ffff60]',
+  fuzzy: 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 hover:shadow-glow-sm',
+  forgot: 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+};
+
+/**
+ * ReviewCard — question first, answer on tap, grade to advance.
+ *
+ * The reveal state is keyed by the card's log_id via `key` at the call
+ * site, so each new card starts hidden.
+ */
+export function ReviewCard({ review, onGrade }: ReviewCardProps) {
+  const [revealed, setRevealed] = React.useState(false);
+
+  return (
+    <Card
+      className="mx-auto w-full max-w-xl"
+      data-testid={LEARNING_TEST_IDS.REVIEW_CARD}
+      aria-label={`Review: ${review.concept}`}
+    >
+      <CardContent className="flex flex-col gap-5 p-6">
+        {/* Concept heading */}
+        <div className="flex items-center gap-2">
+          <Badge variant="outline">Review</Badge>
+          <span className="min-w-0 truncate text-sm font-medium text-muted-foreground">
+            {review.concept}
+          </span>
+        </div>
+
+        {/* Question — tap anywhere to reveal the answer */}
+        <button
+          type="button"
+          onClick={() => setRevealed(true)}
+          disabled={revealed}
+          data-testid={LEARNING_TEST_IDS.REVEAL_BUTTON}
+          aria-expanded={revealed}
+          className={cn(
+            'rounded-lg border border-border/60 bg-background/40 p-4 text-left transition-colors',
+            !revealed && 'cursor-pointer hover:border-primary/40 hover:bg-accent/40',
+            revealed && 'cursor-default'
+          )}
+        >
+          <p className="text-lg leading-relaxed text-foreground">{review.question}</p>
+          {!revealed && (
+            <p className="mt-3 text-xs uppercase tracking-wide text-muted-foreground">
+              タップで答えを表示
+            </p>
+          )}
+        </button>
+
+        {/* Answer */}
+        {revealed && (
+          <div
+            data-testid={LEARNING_TEST_IDS.ANSWER}
+            className="rounded-lg border border-primary/20 bg-primary/5 p-4"
+          >
+            <p className="whitespace-pre-line text-base leading-relaxed text-foreground">
+              {review.answer}
+            </p>
+          </div>
+        )}
+
+        {/* Grade buttons — only after the answer is shown */}
+        {revealed && (
+          <div className="grid grid-cols-3 gap-3">
+            {GRADE_OPTIONS.map(({ result, symbol, label }) => (
+              <button
+                key={result}
+                type="button"
+                onClick={() => onGrade(result)}
+                data-testid={`${LEARNING_TEST_IDS.GRADE_BUTTON}-${result}`}
+                aria-label={label}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-1 rounded-lg border py-4 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                  GRADE_BUTTON_STYLES[result]
+                )}
+              >
+                <span className="text-2xl leading-none" aria-hidden="true">
+                  {symbol}
+                </span>
+                <span className="text-xs font-medium">{label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/constants/learning.ts
+++ b/src/constants/learning.ts
@@ -1,0 +1,56 @@
+/**
+ * Learning (spaced repetition) constants
+ *
+ * Shared labels and test IDs for the grading page, tracker, and book
+ * management. Grading is the primary mobile flow (細切れ時間に片手で),
+ * so labels stay short and the three results map to ○ △ ×.
+ */
+
+import type { GradeResult } from '@/types/api';
+
+/**
+ * Grade options in display order (good → fuzzy → forgot), with the
+ * symbol/label shown on the big grading buttons.
+ */
+export const GRADE_OPTIONS: ReadonlyArray<{
+  result: GradeResult;
+  symbol: string;
+  label: string;
+}> = [
+  { result: 'good', symbol: '○', label: 'わかった' },
+  { result: 'fuzzy', symbol: '△', label: 'あいまい' },
+  { result: 'forgot', symbol: '×', label: '忘れた' },
+] as const;
+
+/**
+ * book_review status labels for the book management screen.
+ */
+export const BOOK_STATUS_LABELS: Record<string, string> = {
+  idle: 'Idle',
+  active: 'In progress',
+  finished: 'Finished',
+};
+
+/**
+ * Test IDs for learning-related components.
+ */
+export const LEARNING_TEST_IDS = {
+  /** The grading review card container */
+  REVIEW_CARD: 'review-card',
+  /** Tappable question area that reveals the answer */
+  REVEAL_BUTTON: 'review-reveal-button',
+  /** Revealed answer block */
+  ANSWER: 'review-answer',
+  /** Grade button prefix (suffixed with the result: -good/-fuzzy/-forgot) */
+  GRADE_BUTTON: 'review-grade-button',
+  /** Empty state shown when nothing is pending */
+  EMPTY: 'review-empty',
+  /** A tracker item row/card */
+  ITEM: 'learning-item',
+  /** Manual retire button on a tracker item */
+  RETIRE_BUTTON: 'learning-item-retire-button',
+  /** A book row/card in the book manager */
+  BOOK: 'learning-book',
+  /** Activate / deactivate toggle on a book */
+  BOOK_TOGGLE: 'learning-book-toggle',
+} as const;

--- a/src/hooks/useLearning.test.ts
+++ b/src/hooks/useLearning.test.ts
@@ -1,0 +1,146 @@
+/**
+ * useLearning hook tests
+ *
+ * Focus on the load-bearing grading logic: optimistic removal from the
+ * pending cache, 409 (already graded) being absorbed as a skip, and other
+ * errors rolling the cache back.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { usePendingReviews, useGradeReview } from './useLearning';
+import * as learningApi from '@/lib/api/endpoints/learning';
+import { ApiError } from '@/lib/api/errors';
+import type { PendingReview } from '@/types/api';
+
+vi.mock('@/lib/api/endpoints/learning', () => ({
+  getPendingReviews: vi.fn(),
+  gradeReview: vi.fn(),
+  getLearningItems: vi.fn(),
+  retireLearningItem: vi.fn(),
+  getLearningBooks: vi.fn(),
+  activateBook: vi.fn(),
+  deactivateBook: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const PENDING_KEY = ['learning', 'reviews', 'pending'];
+
+const reviews: PendingReview[] = [
+  {
+    log_id: 1,
+    item_id: 10,
+    asked_on: '2026-07-07',
+    concept: 'A',
+    question: 'qa',
+    answer: 'aa',
+  },
+  {
+    log_id: 2,
+    item_id: 11,
+    asked_on: '2026-07-07',
+    concept: 'B',
+    question: 'qb',
+    answer: 'ab',
+  },
+];
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapperFor(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe('usePendingReviews', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the fetched reviews', async () => {
+    vi.mocked(learningApi.getPendingReviews).mockResolvedValue(reviews);
+    const client = makeClient();
+
+    const { result } = renderHook(() => usePendingReviews(), {
+      wrapper: wrapperFor(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.reviews).toEqual(reviews);
+  });
+});
+
+describe('useGradeReview', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('optimistically removes the graded log from the pending cache', async () => {
+    vi.mocked(learningApi.gradeReview).mockResolvedValue({
+      log_id: 1,
+      item_id: 10,
+      result: 'good',
+      stage: 1,
+      due_on: '2026-07-14',
+      retired: false,
+    });
+    const client = makeClient();
+    client.setQueryData(PENDING_KEY, reviews);
+
+    const { result } = renderHook(() => useGradeReview(), {
+      wrapper: wrapperFor(client),
+    });
+
+    act(() => {
+      result.current.grade({ logId: 1, result: 'good' });
+    });
+
+    await waitFor(() => expect(learningApi.gradeReview).toHaveBeenCalled());
+    const cache = client.getQueryData<PendingReview[]>(PENDING_KEY);
+    expect(cache?.map((r) => r.log_id)).toEqual([2]);
+  });
+
+  it('keeps the log removed on a 409 (already graded)', async () => {
+    vi.mocked(learningApi.gradeReview).mockRejectedValue(new ApiError('Already graded', 409));
+    const client = makeClient();
+    client.setQueryData(PENDING_KEY, reviews);
+
+    const { result } = renderHook(() => useGradeReview(), {
+      wrapper: wrapperFor(client),
+    });
+
+    act(() => {
+      result.current.grade({ logId: 1, result: 'forgot' });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    const cache = client.getQueryData<PendingReview[]>(PENDING_KEY);
+    expect(cache?.map((r) => r.log_id)).toEqual([2]);
+  });
+
+  it('rolls the cache back on a non-409 error', async () => {
+    vi.mocked(learningApi.gradeReview).mockRejectedValue(new ApiError('Server error', 500));
+    const client = makeClient();
+    client.setQueryData(PENDING_KEY, reviews);
+
+    const { result } = renderHook(() => useGradeReview(), {
+      wrapper: wrapperFor(client),
+    });
+
+    act(() => {
+      result.current.grade({ logId: 1, result: 'good' });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    const cache = client.getQueryData<PendingReview[]>(PENDING_KEY);
+    expect(cache?.map((r) => r.log_id)).toEqual([1, 2]);
+  });
+});

--- a/src/hooks/useLearning.ts
+++ b/src/hooks/useLearning.ts
@@ -1,0 +1,222 @@
+/**
+ * Learning (spaced repetition) hooks
+ *
+ * React Query hooks for the grading page, tracker, and book management.
+ *
+ * Cache design:
+ * - ['learning', 'reviews', 'pending']   - pending review queue (grading)
+ * - ['learning', 'items', status]        - tracker list per status
+ * - ['learning', 'books']                - book manager list
+ *
+ * Grading is optimistic: the visible card advances instantly (driven by the
+ * caller's local "processed" set), and the pending log is removed from the
+ * cache on mutate so it never reappears. A 409 (already graded elsewhere —
+ * another device or the 48h auto-advance) is treated as success and quietly
+ * skipped; any other failure rolls the cache back so a genuinely-ungraded
+ * item can resurface on the next visit.
+ */
+
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getPendingReviews,
+  gradeReview,
+  getLearningItems,
+  retireLearningItem,
+  getLearningBooks,
+  activateBook,
+  deactivateBook,
+} from '@/lib/api/endpoints/learning';
+import { ApiError } from '@/lib/api/errors';
+import { logger } from '@/lib/logger';
+import type {
+  PendingReview,
+  GradeResult,
+  LearningItem,
+  LearningItemStatus,
+  LearningBook,
+} from '@/types/api';
+
+const PENDING_KEY = ['learning', 'reviews', 'pending'] as const;
+
+/**
+ * Fetch the pending review queue (oldest first). Empty = nothing to grade
+ * today (a normal state, surfaced as a friendly empty view — not an error).
+ */
+export function usePendingReviews(options?: { enabled?: boolean }) {
+  const query = useQuery({
+    queryKey: PENDING_KEY,
+    queryFn: getPendingReviews,
+    // Keep the deck stable while grading; don't refetch mid-session.
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+    enabled: options?.enabled ?? true,
+  });
+
+  return {
+    reviews: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+    refetch: () => {
+      query.refetch();
+    },
+  };
+}
+
+/**
+ * Grade a review (○△×). One-shot on the backend; optimistic on the client.
+ *
+ * The caller advances the UI locally the instant a grade is tapped. This
+ * mutation keeps the cache consistent: it drops the graded log from the
+ * pending list on mutate, keeps it dropped on success or 409, and restores
+ * it on any other error.
+ */
+export function useGradeReview() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ logId, result }: { logId: number; result: GradeResult }) =>
+      gradeReview(logId, result),
+    onMutate: async ({ logId }) => {
+      // Cancel in-flight refetches so they don't clobber our optimistic drop.
+      await queryClient.cancelQueries({ queryKey: PENDING_KEY });
+      const previous = queryClient.getQueryData<PendingReview[]>(PENDING_KEY);
+      queryClient.setQueryData<PendingReview[]>(PENDING_KEY, (old) =>
+        (old ?? []).filter((r) => r.log_id !== logId)
+      );
+      return { previous };
+    },
+    onError: (error, { logId }, context) => {
+      // 409 = already graded (another device / 48h auto). Correct to skip —
+      // leave it dropped from the queue.
+      if (error instanceof ApiError && error.status === 409) {
+        logger.debug('Review already graded, skipping', { logId });
+        return;
+      }
+      // Genuine failure: roll the pending list back so the item isn't lost.
+      // (The caller's local "processed" set still hides it for this session;
+      // it resurfaces on the next visit / refetch.)
+      if (context?.previous) {
+        queryClient.setQueryData(PENDING_KEY, context.previous);
+      }
+    },
+    onSuccess: () => {
+      // The item's stage/due_on changed — refresh the tracker lazily.
+      queryClient.invalidateQueries({ queryKey: ['learning', 'items'] });
+    },
+  });
+
+  return {
+    grade: mutation.mutate,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+  };
+}
+
+/**
+ * Fetch tracker items filtered by status (active / retired).
+ */
+export function useLearningItems(status: LearningItemStatus, options?: { enabled?: boolean }) {
+  const query = useQuery({
+    queryKey: ['learning', 'items', status],
+    queryFn: () => getLearningItems(status),
+    staleTime: 30000,
+    retry: 1,
+    enabled: options?.enabled ?? true,
+  });
+
+  return {
+    items: (query.data ?? []) as LearningItem[],
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+    refetch: () => {
+      query.refetch();
+    },
+  };
+}
+
+/**
+ * Manually retire (archive) a learning item. Idempotent.
+ */
+export function useRetireItem() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: number) => retireLearningItem(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['learning', 'items'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+    reset: mutation.reset,
+  };
+}
+
+/**
+ * Fetch ingested books with review progress.
+ */
+export function useLearningBooks(options?: { enabled?: boolean }) {
+  const query = useQuery({
+    queryKey: ['learning', 'books'],
+    queryFn: getLearningBooks,
+    staleTime: 30000,
+    retry: 1,
+    enabled: options?.enabled ?? true,
+  });
+
+  return {
+    books: (query.data ?? []) as LearningBook[],
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+    refetch: () => {
+      query.refetch();
+    },
+  };
+}
+
+/**
+ * Activate a book (set as the single in-progress book — an implicit
+ * swap with whatever was active). Activating a finished book restarts it.
+ */
+export function useActivateBook() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: number) => activateBook(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['learning', 'books'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+  };
+}
+
+/**
+ * Deactivate a book (pause / remove from rotation, cursor kept). Idempotent.
+ */
+export function useDeactivateBook() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: number) => deactivateBook(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['learning', 'books'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+  };
+}

--- a/src/lib/api/endpoints/__tests__/learning.test.ts
+++ b/src/lib/api/endpoints/__tests__/learning.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getPendingReviews,
+  gradeReview,
+  getLearningItems,
+  retireLearningItem,
+  getLearningBooks,
+  activateBook,
+  deactivateBook,
+} from '../learning';
+import { apiClient } from '@/lib/api/client';
+import { ApiError } from '@/lib/api/errors';
+import type { PendingReview, LearningItem, LearningBook } from '@/types/api';
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockReview: PendingReview = {
+  log_id: 12,
+  item_id: 3,
+  asked_on: '2026-07-07',
+  concept: 'goroutine リーク検出',
+  question: 'goroutine リークはどう検出する?',
+  answer: 'pprof の goroutine プロファイルで数の増加を見る。',
+};
+
+describe('Learning API Endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPendingReviews', () => {
+    it('calls GET /learning/reviews/pending', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue([mockReview]);
+
+      const result = await getPendingReviews();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/learning/reviews/pending');
+      expect(result).toEqual([mockReview]);
+    });
+  });
+
+  describe('gradeReview', () => {
+    it('POSTs the result to /learning/reviews/:id/grade', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ log_id: 12, result: 'good' });
+
+      await gradeReview(12, 'good');
+
+      expect(apiClient.post).toHaveBeenCalledWith('/learning/reviews/12/grade', {
+        result: 'good',
+      });
+    });
+
+    it('propagates a 409 (already graded)', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new ApiError('Already graded', 409));
+
+      await expect(gradeReview(12, 'forgot')).rejects.toThrow('Already graded');
+    });
+  });
+
+  describe('getLearningItems', () => {
+    it('calls GET /learning/items without a status', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue([]);
+
+      await getLearningItems();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/learning/items');
+    });
+
+    it('appends the status query param', async () => {
+      const item: LearningItem = {
+        id: 3,
+        kind: 'article',
+        article_id: 42,
+        book_id: null,
+        concept: 'goroutine リーク検出',
+        question: 'q',
+        answer: 'a',
+        provider: 'gemini',
+        stage: 1,
+        due_on: '2026-07-14',
+        retired_at: null,
+        created_at: '2026-07-07T00:00:00Z',
+        times_asked: 2,
+        last_result: 'good',
+        last_asked_on: '2026-07-07',
+      };
+      vi.mocked(apiClient.get).mockResolvedValue([item]);
+
+      const result = await getLearningItems('retired');
+
+      expect(apiClient.get).toHaveBeenCalledWith('/learning/items?status=retired');
+      expect(result).toEqual([item]);
+    });
+  });
+
+  describe('retireLearningItem', () => {
+    it('POSTs to /learning/items/:id/retire', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ id: 3, retired_at: '2026-07-07T00:00:00Z' });
+
+      await retireLearningItem(3);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/learning/items/3/retire');
+    });
+  });
+
+  describe('books', () => {
+    const mockBook: LearningBook = {
+      id: 7,
+      title: 'リーダブルコード',
+      review_status: 'active',
+      review_cursor: 12,
+      total_chunks: 180,
+    };
+
+    it('getLearningBooks calls GET /learning/books', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue([mockBook]);
+
+      const result = await getLearningBooks();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/learning/books');
+      expect(result).toEqual([mockBook]);
+    });
+
+    it('activateBook POSTs to /learning/books/:id/activate', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue(mockBook);
+
+      await activateBook(7);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/learning/books/7/activate');
+    });
+
+    it('deactivateBook POSTs to /learning/books/:id/deactivate', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ ...mockBook, review_status: 'idle' });
+
+      await deactivateBook(7);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/learning/books/7/deactivate');
+    });
+  });
+});

--- a/src/lib/api/endpoints/learning.ts
+++ b/src/lib/api/endpoints/learning.ts
@@ -1,0 +1,121 @@
+/**
+ * Learning (spaced repetition) API Endpoints
+ *
+ * Drives the理解トラッカー: the grading page (/learning), the item tracker
+ * (/learning/items), and book management (/learning/books). All endpoints
+ * require JWT (they ride the existing authenticated client).
+ *
+ * Contract notes:
+ * - POST /reviews/:id/grade is ONE-SHOT: grading an already-graded log
+ *   (manual or 48h auto) returns 409 and cannot be overridden.
+ * - POST /items/:id/retire and POST /books/:id/(de)activate are idempotent.
+ * - Activating a book replaces whatever was active (at most one active book).
+ */
+
+import { apiClient } from '@/lib/api/client';
+import type {
+  PendingReview,
+  GradeResult,
+  GradeResponse,
+  LearningItem,
+  LearningItemStatus,
+  RetireResponse,
+  LearningBook,
+} from '@/types/api';
+
+/**
+ * Fetch pending (ungraded) reviews, oldest first. Empty array = nothing to
+ * grade today (a normal, healthy state — not an error).
+ *
+ * @returns Promise resolving to the pending review list
+ * @throws {ApiError} When the request fails (401, 500)
+ */
+export async function getPendingReviews(): Promise<PendingReview[]> {
+  return apiClient.get<PendingReview[]>('/learning/reviews/pending');
+}
+
+/**
+ * Grade a review (○△×). One-shot: a second grade on the same log returns
+ * 409 (already graded — e.g. another device or the 48h auto-advance won).
+ *
+ * @param logId - review_logs id (log_id from the pending list)
+ * @param result - good | fuzzy | forgot
+ * @returns Promise resolving to the item's new spaced-repetition state
+ * @throws {ApiError} When the request fails (400, 401, 404, 409 already graded)
+ */
+export async function gradeReview(logId: number, result: GradeResult): Promise<GradeResponse> {
+  return apiClient.post<GradeResponse>(`/learning/reviews/${logId}/grade`, { result });
+}
+
+/**
+ * Fetch learning items, filtered by status (defaults to active on the
+ * backend when omitted).
+ *
+ * @param status - 'active' (current) or 'retired' (graduated/archived)
+ * @returns Promise resolving to the item list
+ * @throws {ApiError} When the request fails (400, 401, 500)
+ */
+export async function getLearningItems(status?: LearningItemStatus): Promise<LearningItem[]> {
+  const query = status ? `?status=${status}` : '';
+  return apiClient.get<LearningItem[]>(`/learning/items${query}`);
+}
+
+/**
+ * Manually retire (archive) a learning item — "もう追わなくていい".
+ * Idempotent: retiring an already-retired item returns its record.
+ *
+ * @param id - learning item id
+ * @returns Promise resolving to the retired item record
+ * @throws {ApiError} When the request fails (400, 401, 404)
+ */
+export async function retireLearningItem(id: number): Promise<RetireResponse> {
+  return apiClient.post<RetireResponse>(`/learning/items/${id}/retire`);
+}
+
+/**
+ * Fetch ingested books with their review progress (D-20).
+ *
+ * @returns Promise resolving to the book list
+ * @throws {ApiError} When the request fails (401, 500)
+ */
+export async function getLearningBooks(): Promise<LearningBook[]> {
+  return apiClient.get<LearningBook[]>('/learning/books');
+}
+
+/**
+ * Set a book as the in-progress (active) one. At most one book is active;
+ * the backend demotes the previous active book to idle in one operation.
+ * Activating a `finished` book restarts the read from the beginning.
+ *
+ * @param id - book id
+ * @returns Promise resolving to the updated book
+ * @throws {ApiError} When the request fails (400, 401, 404)
+ */
+export async function activateBook(id: number): Promise<LearningBook> {
+  return apiClient.post<LearningBook>(`/learning/books/${id}/activate`);
+}
+
+/**
+ * Pause / remove a book from rotation (status → idle, cursor kept).
+ * Idempotent.
+ *
+ * @param id - book id
+ * @returns Promise resolving to the updated book
+ * @throws {ApiError} When the request fails (400, 401, 404)
+ */
+export async function deactivateBook(id: number): Promise<LearningBook> {
+  return apiClient.post<LearningBook>(`/learning/books/${id}/deactivate`);
+}
+
+/**
+ * Export types for convenience
+ */
+export type {
+  PendingReview,
+  GradeResult,
+  GradeResponse,
+  LearningItem,
+  LearningItemStatus,
+  RetireResponse,
+  LearningBook,
+};

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -286,6 +286,78 @@ export type AccessLogSummary = Nullable<
 >;
 
 // ============================================================================
+// Learning (spaced repetition) Types
+// ============================================================================
+
+/**
+ * Self-grading result for a review (○△×).
+ * `good` = remembered, `fuzzy` = partial, `forgot` = missed.
+ *
+ * Note: the backend swagger marks `result` optional, but grading always
+ * sends one of these three values (backend is tightening `required`). The
+ * UI treats it as a mandatory field regardless of how the type generates.
+ */
+export type GradeResult = NonNullable<
+  Schemas['internal_handler_http_learning.GradeRequest']['result']
+>;
+
+/**
+ * A pending (ungraded) review shown one card at a time on /learning.
+ * Carries the item's concept / question / answer so the card is
+ * self-contained.
+ */
+export type PendingReview = Full<Schemas['internal_handler_http_learning.PendingReviewDTO']>;
+
+/**
+ * Response of POST /learning/reviews/:id/grade. Reflects the item's new
+ * spaced-repetition state after the grade is applied.
+ */
+export type GradeResponse = Full<Schemas['internal_handler_http_learning.GradeResponse']>;
+
+/**
+ * Learning item kind: derived from a broadcast article or a book chunk.
+ */
+export type LearningItemKind = NonNullable<
+  Schemas['internal_handler_http_learning.ItemDTO']['kind']
+>;
+
+/**
+ * Filter for the tracker list: current (active) vs graduated/archived.
+ */
+export type LearningItemStatus = 'active' | 'retired';
+
+/**
+ * A learning item in the tracker.
+ * `article_id` / `book_id` are set per `kind` (one is null). `retired_at`
+ * null = still active. `last_result` / `last_asked_on` are null until the
+ * item has been asked at least once.
+ */
+export type LearningItem = Nullable<
+  Schemas['internal_handler_http_learning.ItemDTO'],
+  'article_id' | 'book_id' | 'retired_at' | 'last_result' | 'last_asked_on'
+>;
+
+/**
+ * Response of POST /learning/items/:id/retire (idempotent archive).
+ */
+export type RetireResponse = Full<Schemas['internal_handler_http_learning.RetireResponse']>;
+
+/**
+ * book_review progression status.
+ * `idle` = not selected / paused (cursor kept), `active` = in progress
+ * (at most one book at a time), `finished` = fully read.
+ */
+export type BookReviewStatus = NonNullable<
+  Schemas['internal_handler_http_learning.BookDTO']['review_status']
+>;
+
+/**
+ * An ingested book managed from the dashboard (D-20).
+ * `review_cursor` / `total_chunks` drive the progress percentage.
+ */
+export type LearningBook = Full<Schemas['internal_handler_http_learning.BookDTO']>;
+
+// ============================================================================
 // Error Types
 // ============================================================================
 

--- a/src/types/generated/api.d.ts
+++ b/src/types/generated/api.d.ts
@@ -601,6 +601,479 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/learning/books": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 書籍一覧取得(book review 管理)
+         * @description ingest 済み書籍の一覧を返します(D-20)。review_status(idle=未対象/一時停止、active=進行中・常に最大1冊、finished=読了)と review_cursor / total_chunks(進捗率の素材)を含みます
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 書籍一覧 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.BookDTO"][];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning/books/{id}/activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 書籍を進行中に指定
+         * @description 書籍を review_status='active'(book_review コーナーの対象、§7.3)にします。既存の active 書籍があれば同一トランザクションで idle に落とします — 入れ替えが1操作で完結し、active は常に最大1冊です(D-20)。idle からの activate はカーソル保持(一時停止からの再開)、finished からの activate は review_cursor を 0 にリセット(再読開始)。冪等
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 書籍ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 進行中になった書籍 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.BookDTO"];
+                    };
+                };
+                /** @description Bad request - invalid ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - book not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning/books/{id}/deactivate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 書籍の一時停止/対象から除外
+         * @description 進行中の書籍を review_status='idle' に戻します。review_cursor は保持されるため、再度 activate すると続きから再開します(D-20)。冪等: idle の書籍への再実行は 200、finished の書籍は読了マーカーを保持したまま何もしません
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 書籍ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 現在の書籍状態 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.BookDTO"];
+                    };
+                };
+                /** @description Bad request - invalid ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - book not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning/items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 学習項目一覧取得
+         * @description 学習項目(トラッカー)を取得します。status=active(デフォルト)は現役項目を期日順(due_on ASC)、status=retired は卒業・手動アーカイブ済み項目を新しい順(retired_at DESC)で返します。履歴サマリは出題回数と直近結果のみです(§8.1 — 過剰な集計はしない)
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description フィルタ(デフォルト active) */
+                    status?: "active" | "retired";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 学習項目一覧 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.ItemDTO"][];
+                    };
+                };
+                /** @description Bad request - invalid status */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning/items/{id}/retire": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 学習項目の手動アーカイブ
+         * @description 項目を手動でアーカイブします(「もう追わなくていい」)。retired_at をセットするのみで、以後の出題選定から外れます。冪等: アーカイブ済み項目への再実行は元の retired_at をそのまま返します(200)
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 学習項目ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description アーカイブ後の項目(冪等) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.RetireResponse"];
+                    };
+                };
+                /** @description Bad request - invalid ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - learning item not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning/reviews/pending": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 未採点の出題一覧取得
+         * @description 未採点の出題(review log)を古い出題日から順に返します。採点画面(§8.2)用に項目の concept/question/answer を含みます。空配列は正常系です(「今日は採点するものがありません」)— 件数バッジ・期日超過集計は設計で禁止されています(§2 Out)
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 未採点の出題一覧(古い順) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.PendingReviewDTO"][];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning/reviews/{id}/grade": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 採点(一発確定)
+         * @description 出題(review log)に自己採点 ○△×(good/fuzzy/forgot)を記録し、項目のステージ遷移(§6.1、due 起点は採点日 JST)を適用します。**採点は一発確定**: 採点済み(手動・48h 自動解決 result=auto とも)への再採点は 409 を返し、上書きはできません
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 出題ログID(pending の log_id) */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description 採点結果 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler_http_learning.GradeRequest"];
+                };
+            };
+            responses: {
+                /** @description 遷移後の項目状態 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_learning.GradeResponse"];
+                    };
+                };
+                /** @description Bad request - invalid ID or result */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required - missing or invalid JWT token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - review log not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Conflict - already graded (manual, auto-resolved or concurrent) */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sources": {
         parameters: {
             query?: never;
@@ -1492,6 +1965,93 @@ export interface components {
         "internal_handler_http_auth.tokenResponse": {
             /** @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... */
             token?: string;
+        };
+        "internal_handler_http_learning.BookDTO": {
+            /** @example 7 */
+            id?: number;
+            /** @example 12 */
+            review_cursor?: number;
+            /**
+             * @example active
+             * @enum {string}
+             */
+            review_status?: "idle" | "active" | "finished";
+            /** @example リーダブルコード */
+            title?: string;
+            /** @example 180 */
+            total_chunks?: number;
+        };
+        "internal_handler_http_learning.GradeRequest": {
+            /**
+             * @example good
+             * @enum {string}
+             */
+            result?: "good" | "fuzzy" | "forgot";
+        };
+        "internal_handler_http_learning.GradeResponse": {
+            /** @example 2026-07-14 */
+            due_on?: string;
+            /** @example 3 */
+            item_id?: number;
+            /** @example 12 */
+            log_id?: number;
+            /**
+             * @example good
+             * @enum {string}
+             */
+            result?: "good" | "fuzzy" | "forgot";
+            /** @example false */
+            retired?: boolean;
+            /** @example 1 */
+            stage?: number;
+        };
+        "internal_handler_http_learning.ItemDTO": {
+            answer?: string;
+            /** @example 42 */
+            article_id?: number;
+            /** @example 7 */
+            book_id?: number;
+            /** @example goroutine リーク検出 */
+            concept?: string;
+            created_at?: string;
+            /** @example 2026-07-14 */
+            due_on?: string;
+            /** @example 3 */
+            id?: number;
+            /**
+             * @example article
+             * @enum {string}
+             */
+            kind?: "article" | "book";
+            /** @example 2026-07-07 */
+            last_asked_on?: string;
+            /** @example good */
+            last_result?: string;
+            /** @example gemini */
+            provider?: string;
+            question?: string;
+            retired_at?: string;
+            /** @example 1 */
+            stage?: number;
+            /** @example 2 */
+            times_asked?: number;
+        };
+        "internal_handler_http_learning.PendingReviewDTO": {
+            answer?: string;
+            /** @example 2026-07-07 */
+            asked_on?: string;
+            /** @example goroutine リーク検出 */
+            concept?: string;
+            /** @example 3 */
+            item_id?: number;
+            /** @example 12 */
+            log_id?: number;
+            question?: string;
+        };
+        "internal_handler_http_learning.RetireResponse": {
+            /** @example 3 */
+            id?: number;
+            retired_at?: string;
         };
         "internal_handler_http_source.CreateRequest": {
             /** @example go */

--- a/src/types/generated/api.d.ts
+++ b/src/types/generated/api.d.ts
@@ -1986,7 +1986,7 @@ export interface components {
              * @example good
              * @enum {string}
              */
-            result?: "good" | "fuzzy" | "forgot";
+            result: "good" | "fuzzy" | "forgot";
         };
         "internal_handler_http_learning.GradeResponse": {
             /** @example 2026-07-14 */


### PR DESCRIPTION
## 概要

Phase 3(学習ループコア)の frontend 手順5(設計書 §8.2)。2コミット、code-reviewer レビューで blocking ゼロ+確定 swagger からの型再生成済み。

- **/learning 採点ページ**(スマホ第一): 未採点項目をカード1件ずつ表示 → タップで answer 開示 → ○△× の大ボタン。楽観更新+processed Set で連続採点、409(自動解決との競合)は静かにスキップ
- **/learning/items 理解トラッカー**: 現役項目一覧(stage・次回予定日・履歴)、卒業アーカイブ、手動 retire
- **/learning/books 書籍管理**(D-20): 進捗率表示+activate/deactivate(active 最大1冊、別の本の activate は入れ替え)
- 生成 API 型は backend PR #83 の確定 Swagger と一致(`GradeRequest.result` required 化まで追随済み)

## 設計上の不変条件(レビューで検証済み)

- **罪悪感 UI の不在**(§2 Out): 期日超過の警告色・件数バッジ・ストリーク表示なし。「今日は採点するものがありません」を正常系として表示

## マージ順序

backend PR #83 のマージ+Pi 反映**後**にマージしてください(/learning/* API が Pi に存在しない間は各画面がエラー表示になります)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)