### PR TITLE
feat: add read-only viewer accounts (D-27)

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Header } from '@/components/layout/Header';
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth, useMe } from '@/hooks/useAuth';
 
 /**
  * Protected Layout
@@ -17,6 +17,9 @@ export default function ProtectedLayout({
   children: React.ReactNode;
 }>) {
   const { logout } = useAuth();
+  // Role from GET /auth/me (D-27): scopes the header navigation. The proxy
+  // and backend enforce access regardless of what the client renders.
+  const { role } = useMe();
 
   return (
     <div className="relative min-h-screen bg-background">
@@ -26,7 +29,7 @@ export default function ProtectedLayout({
 
       {/* Content */}
       <div className="relative">
-        <Header onLogout={logout} />
+        <Header onLogout={logout} role={role} />
         <main className="px-4 pb-8 sm:px-6 lg:px-8">{children}</main>
       </div>
     </div>

--- a/src/app/(protected)/sources/__tests__/page.test.tsx
+++ b/src/app/(protected)/sources/__tests__/page.test.tsx
@@ -6,6 +6,7 @@ import SourcesPage from '../page';
 import * as sourcesApi from '@/lib/api/endpoints/sources';
 import * as useSources from '@/hooks/useSources';
 import * as useSourceSearch from '@/hooks/useSourceSearch';
+import * as useAuth from '@/hooks/useAuth';
 import { ApiError } from '@/lib/api/errors';
 import type { Source } from '@/types/api';
 
@@ -13,6 +14,7 @@ import type { Source } from '@/types/api';
 vi.mock('@/lib/api/endpoints/sources');
 vi.mock('@/hooks/useSources');
 vi.mock('@/hooks/useSourceSearch');
+vi.mock('@/hooks/useAuth');
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
@@ -93,6 +95,15 @@ describe('SourcesPage', () => {
 
     // Backend responds 204 No Content
     vi.mocked(sourcesApi.updateSourceActive).mockResolvedValue(undefined);
+
+    // Default to the admin role (D-27): management UI is admin-only.
+    // Viewer-specific tests override this per-test.
+    vi.mocked(useAuth.useMe).mockReturnValue({
+      me: { sub: 'admin@example.com', role: 'admin' },
+      role: 'admin',
+      isLoading: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -108,7 +119,7 @@ describe('SourcesPage', () => {
       // Act
       renderWithClient(<SourcesPage />);
 
-      // Assert - single-admin system: authenticated users always see management UI
+      // Assert - the admin role always sees the management UI
       expect(screen.getByRole('button', { name: /add source/i })).toBeInTheDocument();
     });
 
@@ -152,6 +163,54 @@ describe('SourcesPage', () => {
 
         // Third source is active
         expect(toggles[2]).toBeChecked();
+      });
+    });
+  });
+
+  describe('Viewer role (read-only, D-27)', () => {
+    beforeEach(() => {
+      vi.mocked(useAuth.useMe).mockReturnValue({
+        me: { sub: 'friend@example.com', role: 'viewer' },
+        role: 'viewer',
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('should NOT display the Add Source button', () => {
+      renderWithClient(<SourcesPage />);
+
+      expect(screen.queryByRole('button', { name: /add source/i })).not.toBeInTheDocument();
+    });
+
+    it('should NOT display the search panel (search is 403 for viewers)', () => {
+      renderWithClient(<SourcesPage />);
+
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    });
+
+    it('should render read-only cards: StatusBadge instead of toggles, no edit/delete', async () => {
+      renderWithClient(<SourcesPage />);
+
+      await waitFor(() => {
+        // No ActiveToggle switches
+        expect(screen.queryAllByRole('switch')).toHaveLength(0);
+        // StatusBadge text appears instead (server returns active only in
+        // production; the mocked list has 2 active + 1 inactive here)
+        expect(screen.getAllByText('Active').length).toBeGreaterThan(0);
+      });
+
+      expect(screen.queryByRole('button', { name: /edit source/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /delete source/i })).not.toBeInTheDocument();
+    });
+
+    it('should still list the sources themselves', async () => {
+      renderWithClient(<SourcesPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Tech Blog')).toBeInTheDocument();
+        expect(screen.getByText('News Site')).toBeInTheDocument();
+        expect(screen.getByText('Developer Feed')).toBeInTheDocument();
       });
     });
   });

--- a/src/app/(protected)/sources/page.tsx
+++ b/src/app/(protected)/sources/page.tsx
@@ -16,6 +16,7 @@ import { EditSourceDialog } from '@/components/sources/EditSourceDialog';
 import { DeleteSourceDialog } from '@/components/sources/DeleteSourceDialog';
 import { useSources } from '@/hooks/useSources';
 import { useSourceSearch } from '@/hooks/useSourceSearch';
+import { useMe } from '@/hooks/useAuth';
 import { updateSourceActive } from '@/lib/api/endpoints/sources';
 import {
   SourceSearch,
@@ -33,6 +34,13 @@ import type { Source } from '@/types/api';
 function SourcesPageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
+
+  // Role gating (D-27): viewers get a read-only list of active sources
+  // (the backend force-filters GET /sources and 403s search/mutations).
+  // Until the role is known we render the read-only variant so admin-only
+  // controls never flash for a viewer.
+  const { role } = useMe();
+  const isAdmin = role === 'admin';
 
   // Add Source Dialog state
   const [isAddDialogOpen, setIsAddDialogOpen] = React.useState(false);
@@ -58,8 +66,9 @@ function SourcesPageContent() {
     active,
   });
 
-  // Determine if we're in search mode
-  const isSearchMode = hasActiveFilters(searchState);
+  // Determine if we're in search mode (admin only — GET /sources/search is
+  // 403 for viewers, so a viewer never issues search requests)
+  const isSearchMode = isAdmin && hasActiveFilters(searchState);
 
   // Fetch sources - conditionally enable based on mode to prevent duplicate API calls
   const listResult = useSources({ enabled: !isSearchMode });
@@ -181,22 +190,26 @@ function SourcesPageContent() {
 
   return (
     <div className="container py-8">
-      {/* Page Header with Add Button */}
+      {/* Page Header with Add Button (admin only) */}
       <div className="mb-6 flex items-start justify-between gap-4">
         <PageHeader title="Sources" description="RSS/Atom feeds being tracked" />
 
-        <Button onClick={() => setIsAddDialogOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Add Source
-        </Button>
+        {isAdmin && (
+          <Button onClick={() => setIsAddDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Source
+          </Button>
+        )}
       </div>
 
-      {/* Search and Filter Panel */}
-      <SourceSearch
-        searchState={searchState}
-        onSearchChange={setSearchState}
-        isLoading={isLoading}
-      />
+      {/* Search and Filter Panel (admin only — search is 403 for viewers) */}
+      {isAdmin && (
+        <SourceSearch
+          searchState={searchState}
+          onSearchChange={setSearchState}
+          isLoading={isLoading}
+        />
+      )}
 
       {/* Error State */}
       {error && (
@@ -243,15 +256,21 @@ function SourcesPageContent() {
       {!isLoading && !error && sources.length > 0 && (
         <>
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {sources.map((source) => (
-              <SourceCard
-                key={source.id}
-                source={source}
-                onUpdateActive={handleUpdateActive}
-                onEdit={handleEditSource}
-                onDelete={handleDeleteSource}
-              />
-            ))}
+            {sources.map((source) =>
+              isAdmin ? (
+                <SourceCard
+                  key={source.id}
+                  source={source}
+                  onUpdateActive={handleUpdateActive}
+                  onEdit={handleEditSource}
+                  onDelete={handleDeleteSource}
+                />
+              ) : (
+                // Viewer (D-27): no handlers → SourceCard renders its
+                // read-only variant (StatusBadge, no edit/delete/toggle)
+                <SourceCard key={source.id} source={source} />
+              )
+            )}
           </div>
 
           {/* Total Count */}
@@ -263,13 +282,13 @@ function SourcesPageContent() {
 
       {/* Add Source Dialog */}
       <AddSourceDialog
-        isOpen={isAddDialogOpen}
+        isOpen={isAdmin && isAddDialogOpen}
         onClose={() => setIsAddDialogOpen(false)}
         onSuccess={() => setIsAddDialogOpen(false)}
       />
 
       {/* Edit Source Dialog */}
-      {selectedSource && (
+      {isAdmin && selectedSource && (
         <EditSourceDialog
           isOpen={editDialogOpen}
           onClose={handleEditDialogClose}
@@ -278,7 +297,7 @@ function SourcesPageContent() {
       )}
 
       {/* Delete Source Dialog */}
-      {sourceToDelete && (
+      {isAdmin && sourceToDelete && (
         <DeleteSourceDialog
           isOpen={deleteDialogOpen}
           onClose={handleDeleteDialogClose}
@@ -294,8 +313,10 @@ function SourcesPageContent() {
  * Sources List Page
  *
  * Protected page that displays a grid of RSS/Atom feed sources.
- * The system has a single administrator (C-7/C-20): any authenticated
- * user is the admin, so management controls are always shown here.
+ * The admin (C-7) gets full management controls; `viewer` accounts (D-27)
+ * get a read-only list of active sources — the backend force-filters
+ * GET /sources and rejects search/mutations with 403, so the UI gating
+ * here is presentation only.
  * Requires authentication - unauthenticated users will be redirected by the proxy.
  *
  * Wrapped in Suspense boundary for useSearchParams compatibility with Next.js 15.

--- a/src/app/(protected)/viewers/page.tsx
+++ b/src/app/(protected)/viewers/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import * as React from 'react';
+import { Eye, Plus } from 'lucide-react';
+import { PageHeader } from '@/components/common/PageHeader';
+import { ErrorMessage } from '@/components/common/ErrorMessage';
+import { ErrorAlert } from '@/components/common/ErrorAlert';
+import { EmptyState } from '@/components/common/EmptyState';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { ViewerCard } from '@/components/viewers/ViewerCard';
+import { AddViewerDialog } from '@/components/viewers/AddViewerDialog';
+import { EditViewerDialog } from '@/components/viewers/EditViewerDialog';
+import { DeleteViewerDialog } from '@/components/viewers/DeleteViewerDialog';
+import { useViewers, useSetViewerActive } from '@/hooks/useViewers';
+import type { Viewer } from '@/types/api';
+
+/**
+ * Viewers (read-only accounts) list page — admin only (D-27).
+ *
+ * CRUD for friend accounts that can log in and browse the active source
+ * list. Deactivation is a reversible logical toggle (takes effect on the
+ * viewer's next request); deletion is PHYSICAL and confirmed via dialog.
+ * The proxy redirects viewer-role sessions away from this page, and every
+ * /viewers API is admin-only server-side.
+ */
+export default function ViewersPage() {
+  const { viewers, isLoading, error, refetch } = useViewers();
+  const toggleActive = useSetViewerActive();
+
+  const [isAddOpen, setIsAddOpen] = React.useState(false);
+  const [viewerToEdit, setViewerToEdit] = React.useState<Viewer | null>(null);
+  const [viewerToDelete, setViewerToDelete] = React.useState<Viewer | null>(null);
+  const [togglingId, setTogglingId] = React.useState<number | null>(null);
+
+  const activeCount = viewers.filter((v) => v.active).length;
+  const inactiveCount = viewers.length - activeCount;
+
+  /**
+   * Toggle active/deactivated directly from the card. No confirmation
+   * dialog: the operation is reversible (unlike delete). Errors surface
+   * via the ErrorAlert below the header.
+   */
+  const handleToggleActive = React.useCallback(
+    async (viewer: Viewer) => {
+      setTogglingId(viewer.id);
+      try {
+        await toggleActive.mutateAsync({ id: viewer.id, active: !viewer.active });
+      } catch {
+        // Error surfaces through toggleActive.error
+      } finally {
+        setTogglingId(null);
+      }
+    },
+    [toggleActive]
+  );
+
+  return (
+    <div className="container py-8">
+      {/* Page Header with Add button */}
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <PageHeader
+          title="Viewers"
+          description={
+            viewers.length > 0
+              ? `${activeCount} active${inactiveCount > 0 ? `, ${inactiveCount} deactivated` : ''}`
+              : 'Read-only accounts for friends to browse the source list'
+          }
+        />
+        <Button onClick={() => setIsAddOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Viewer
+        </Button>
+      </div>
+
+      {/* List fetch error */}
+      {error && (
+        <div className="mb-6">
+          <ErrorMessage error={error} onRetry={refetch} />
+        </div>
+      )}
+
+      {/* Activate/deactivate toggle error */}
+      <ErrorAlert error={toggleActive.error} />
+
+      {/* Loading State */}
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-lg border bg-card p-6">
+              <div className="mb-4 flex items-start gap-3">
+                <Skeleton className="h-10 w-10 rounded" />
+                <div className="flex-1">
+                  <Skeleton className="mb-2 h-5 w-3/4" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && !error && viewers.length === 0 && (
+        <EmptyState
+          title="No viewers yet"
+          description="Create a read-only account so a friend can browse your source list and tell you what to add or drop."
+          icon={<Eye className="h-12 w-12" />}
+          action={
+            <Button onClick={() => setIsAddOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Viewer
+            </Button>
+          }
+        />
+      )}
+
+      {/* Viewers grid */}
+      {!isLoading && !error && viewers.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3" role="list">
+          {viewers.map((viewer) => (
+            <ViewerCard
+              key={viewer.id}
+              viewer={viewer}
+              onEdit={setViewerToEdit}
+              onToggleActive={handleToggleActive}
+              onDelete={setViewerToDelete}
+              isToggling={togglingId === viewer.id}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Dialogs */}
+      <AddViewerDialog isOpen={isAddOpen} onClose={() => setIsAddOpen(false)} />
+      <EditViewerDialog
+        viewer={viewerToEdit}
+        isOpen={viewerToEdit !== null}
+        onClose={() => setViewerToEdit(null)}
+      />
+      <DeleteViewerDialog
+        viewer={viewerToDelete}
+        isOpen={viewerToDelete !== null}
+        onClose={() => setViewerToDelete(null)}
+      />
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,30 +9,46 @@ import { Menu, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import { cn } from '@/lib/utils';
+import type { UserRole } from '@/types/api';
 
 interface HeaderProps {
   onLogout?: () => void;
   showAuthLinks?: boolean;
+  /**
+   * Authenticated role from GET /auth/me (D-27). Viewers only see the
+   * Sources link; undefined (still loading / unknown) hides the main nav
+   * so admin-only links never flash for a viewer. Logout stays visible
+   * regardless (POST /auth/logout is a public endpoint).
+   */
+  role?: UserRole;
 }
 
-const mainNavigation = [
+const adminNavigation = [
   { name: 'Dashboard', href: '/dashboard' },
   { name: 'Articles', href: '/articles' },
   { name: 'Sources', href: '/sources' },
   { name: 'Books', href: '/books' },
   { name: 'Friends', href: '/subscribers' },
+  { name: 'Viewers', href: '/viewers' },
   { name: 'Access Logs', href: '/access-logs' },
   { name: 'Review', href: '/learning' },
 ];
+
+const viewerNavigation = [{ name: 'Sources', href: '/sources' }];
 
 const legalNavigation = [
   { name: 'Terms', href: '/terms' },
   { name: 'Privacy', href: '/privacy' },
 ];
 
-export function Header({ onLogout, showAuthLinks = true }: HeaderProps) {
+export function Header({ onLogout, showAuthLinks = true, role }: HeaderProps) {
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
+
+  // Role-scoped main navigation (D-27): admin sees everything, viewer only
+  // Sources, unknown role (loading) shows nothing yet.
+  const mainNavigation =
+    role === 'admin' ? adminNavigation : role === 'viewer' ? viewerNavigation : [];
 
   const handleLogout = () => {
     if (onLogout) {
@@ -56,7 +72,7 @@ export function Header({ onLogout, showAuthLinks = true }: HeaderProps) {
         {/* Logo */}
         <div className="flex items-center">
           <Link
-            href="/dashboard"
+            href={role === 'viewer' ? '/sources' : '/dashboard'}
             data-testid="header-logo"
             className="group flex items-center space-x-2 transition-all duration-200"
           >
@@ -101,7 +117,9 @@ export function Header({ onLogout, showAuthLinks = true }: HeaderProps) {
             })}
 
           {/* Divider */}
-          {showAuthLinks && <div className="mx-2 h-6 w-px bg-border/50" />}
+          {showAuthLinks && mainNavigation.length > 0 && (
+            <div className="mx-2 h-6 w-px bg-border/50" />
+          )}
 
           {/* Legal navigation (public pages) */}
           {legalNavigation.map((item) => {
@@ -180,7 +198,9 @@ export function Header({ onLogout, showAuthLinks = true }: HeaderProps) {
               })}
 
             {/* Legal navigation */}
-            {showAuthLinks && <div className="my-2 border-t border-border/30 pt-2" />}
+            {showAuthLinks && mainNavigation.length > 0 && (
+              <div className="my-2 border-t border-border/30 pt-2" />
+            )}
             {legalNavigation.map((item) => {
               const isActive = pathname === item.href;
               return (

--- a/src/components/viewers/AddViewerDialog.tsx
+++ b/src/components/viewers/AddViewerDialog.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ViewerForm } from './ViewerForm';
+import { useCreateViewer } from '@/hooks/useViewers';
+import type { ViewerFormData } from '@/utils/validation/viewerValidation';
+
+interface AddViewerDialogProps {
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Callback when the dialog should close */
+  onClose: () => void;
+  /** Optional callback when the viewer is successfully created */
+  onSuccess?: () => void;
+}
+
+/**
+ * AddViewerDialog - dialog for creating a read-only viewer account (D-27).
+ *
+ * The admin sets the initial password here and shares it with the friend
+ * out-of-band (the app never emails credentials).
+ */
+export function AddViewerDialog({ isOpen, onClose, onSuccess }: AddViewerDialogProps) {
+  const { mutateAsync, isPending, error, reset } = useCreateViewer();
+
+  const handleSubmit = async (data: ViewerFormData) => {
+    try {
+      await mutateAsync({
+        name: data.name,
+        email: data.email,
+        password: data.password,
+      });
+      reset();
+      onSuccess?.();
+      onClose();
+    } catch {
+      // Error surfaces through the mutation error state in ViewerForm
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Viewer</DialogTitle>
+          <DialogDescription>
+            Create a read-only account for a friend. They can log in with this email and password to
+            browse the active source list — nothing else. Share the password with them yourself.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ViewerForm
+          mode="create"
+          onSubmit={handleSubmit}
+          isLoading={isPending}
+          error={error}
+          onCancel={handleClose}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/viewers/DeleteViewerDialog.tsx
+++ b/src/components/viewers/DeleteViewerDialog.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as React from 'react';
+import { Loader2, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ErrorAlert } from '@/components/common/ErrorAlert';
+import { useDeleteViewer } from '@/hooks/useViewers';
+import { VIEWER_TEST_IDS } from '@/constants/viewer';
+import type { Viewer } from '@/types/api';
+
+interface DeleteViewerDialogProps {
+  /** The viewer to delete (null = dialog hidden) */
+  viewer: Viewer | null;
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Callback when the dialog should close */
+  onClose: () => void;
+  /** Optional callback after successful deletion */
+  onSuccess?: () => void;
+}
+
+/**
+ * DeleteViewerDialog - confirmation for the PHYSICAL delete.
+ *
+ * Unlike subscribers (soft delete), deleting a viewer permanently removes
+ * the account (D-27 (4)). The wording makes the irreversibility explicit;
+ * for a temporary block, deactivation is the right tool.
+ */
+export function DeleteViewerDialog({
+  viewer,
+  isOpen,
+  onClose,
+  onSuccess,
+}: DeleteViewerDialogProps) {
+  const { mutateAsync, isPending, error, reset } = useDeleteViewer();
+
+  const handleConfirm = async () => {
+    if (!viewer) {
+      return;
+    }
+    try {
+      await mutateAsync(viewer.id);
+      reset();
+      onSuccess?.();
+      onClose();
+    } catch {
+      // Error shown via ErrorAlert
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  if (!viewer) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent data-testid={VIEWER_TEST_IDS.DELETE_DIALOG}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Trash2 className="h-5 w-5 text-destructive" aria-hidden="true" />
+            Delete {viewer.name}?
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                This PERMANENTLY deletes {viewer.name}&apos;s viewer account ({viewer.email}). They
+                will no longer be able to log in, and the account cannot be recovered.
+              </p>
+              <p className="text-xs text-muted-foreground">
+                To block access temporarily instead, use Deactivate — it can be reversed at any
+                time.
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <ErrorAlert error={error} />
+
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" onClick={handleClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isPending}
+            data-testid={VIEWER_TEST_IDS.DELETE_CONFIRM_BUTTON}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete Permanently'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/viewers/EditViewerDialog.tsx
+++ b/src/components/viewers/EditViewerDialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ViewerForm } from './ViewerForm';
+import { useUpdateViewer } from '@/hooks/useViewers';
+import type { Viewer } from '@/types/api';
+import type { ViewerFormData } from '@/utils/validation/viewerValidation';
+
+interface EditViewerDialogProps {
+  /** The viewer being edited (null = dialog hidden) */
+  viewer: Viewer | null;
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Callback when the dialog should close */
+  onClose: () => void;
+  /** Optional callback when the viewer is successfully updated */
+  onSuccess?: () => void;
+}
+
+/**
+ * EditViewerDialog - dialog for editing a viewer account (D-27).
+ *
+ * Name and email are always sent; the password is only included in the PUT
+ * body when the field is non-empty (blank = keep the current password).
+ */
+export function EditViewerDialog({ viewer, isOpen, onClose, onSuccess }: EditViewerDialogProps) {
+  const { mutateAsync, isPending, error, reset } = useUpdateViewer();
+
+  const handleSubmit = async (data: ViewerFormData) => {
+    if (!viewer) {
+      return;
+    }
+    try {
+      await mutateAsync({
+        id: viewer.id,
+        input: {
+          name: data.name,
+          email: data.email,
+          // Only reset the password when one was typed; omitting the key
+          // keeps the current password (backend contract).
+          ...(data.password ? { password: data.password } : {}),
+        },
+      });
+      reset();
+      onSuccess?.();
+      onClose();
+    } catch {
+      // Error surfaces through the mutation error state in ViewerForm
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  if (!viewer) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Viewer</DialogTitle>
+          <DialogDescription>
+            Update {viewer.name}&apos;s account. Leave the password blank to keep their current
+            password.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ViewerForm
+          key={viewer.id}
+          mode="edit"
+          initialData={{
+            name: viewer.name,
+            email: viewer.email,
+            password: '',
+          }}
+          onSubmit={handleSubmit}
+          isLoading={isPending}
+          error={error}
+          onCancel={handleClose}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/viewers/ViewerCard.stories.tsx
+++ b/src/components/viewers/ViewerCard.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ViewerCard } from './ViewerCard';
+import type { Viewer } from '@/types/api';
+
+/**
+ * ViewerCard Component
+ *
+ * Displays a read-only viewer account (D-27) with active/deactivated
+ * status, login email, and management actions. Deactivation is a
+ * reversible logical toggle; deletion is physical.
+ */
+const meta = {
+  title: 'Viewers/ViewerCard',
+  component: ViewerCard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ViewerCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const activeViewer: Viewer = {
+  id: 1,
+  name: 'Alice',
+  email: 'alice@example.com',
+  active: true,
+  created_at: '2026-07-01T09:00:00Z',
+  updated_at: '2026-07-01T09:00:00Z',
+  deactivated_at: null,
+};
+
+const deactivatedViewer: Viewer = {
+  ...activeViewer,
+  id: 2,
+  name: 'Bob',
+  email: 'bob@example.com',
+  active: false,
+  deactivated_at: '2026-07-10T12:00:00Z',
+};
+
+/**
+ * Active viewer with all actions
+ */
+export const Active: Story = {
+  args: {
+    viewer: activeViewer,
+    onEdit: () => {},
+    onToggleActive: () => {},
+    onDelete: () => {},
+  },
+};
+
+/**
+ * Deactivated viewer (greyed out, toggle shows Reactivate)
+ */
+export const Deactivated: Story = {
+  args: {
+    viewer: deactivatedViewer,
+    onEdit: () => {},
+    onToggleActive: () => {},
+    onDelete: () => {},
+  },
+};
+
+/**
+ * Toggle in flight (button disabled)
+ */
+export const Toggling: Story = {
+  args: {
+    viewer: activeViewer,
+    onEdit: () => {},
+    onToggleActive: () => {},
+    onDelete: () => {},
+    isToggling: true,
+  },
+};

--- a/src/components/viewers/ViewerCard.tsx
+++ b/src/components/viewers/ViewerCard.tsx
@@ -1,0 +1,138 @@
+/**
+ * ViewerCard Component
+ *
+ * Displays a read-only viewer account (D-27) in a card format:
+ * - Name + active/deactivated badge (logical deactivation, reversible)
+ * - Login email
+ * - Added date
+ * - Edit, activate/deactivate toggle, and delete (PHYSICAL) actions
+ */
+import * as React from 'react';
+import { Eye, Pencil, Trash2, UserRoundCheck, UserRoundX } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { formatRelativeTime } from '@/lib/utils/formatDate';
+import { VIEWER_TEST_IDS } from '@/constants/viewer';
+import type { Viewer } from '@/types/api';
+
+interface ViewerCardProps {
+  /** The viewer to display */
+  viewer: Viewer;
+  /** Additional CSS classes */
+  className?: string;
+  /** Callback when edit is clicked */
+  onEdit?: (viewer: Viewer) => void;
+  /** Callback when the activate/deactivate toggle is clicked */
+  onToggleActive?: (viewer: Viewer) => void;
+  /** Callback when delete is clicked (physical delete — confirm downstream) */
+  onDelete?: (viewer: Viewer) => void;
+  /** Disables the toggle while a toggle mutation is in flight */
+  isToggling?: boolean;
+}
+
+/**
+ * ViewerCard displays a viewer account in a card format.
+ */
+export const ViewerCard = React.memo(function ViewerCard({
+  viewer,
+  className,
+  onEdit,
+  onToggleActive,
+  onDelete,
+  isToggling = false,
+}: ViewerCardProps) {
+  return (
+    <Card
+      className={cn('flex flex-col', !viewer.active && 'opacity-70', className)}
+      role="listitem"
+      aria-label={`Viewer: ${viewer.name}`}
+      data-testid={VIEWER_TEST_IDS.CARD}
+    >
+      <CardContent className="flex flex-col gap-4 p-6">
+        {/* Icon, name, status */}
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-primary/30 bg-primary/10">
+            <Eye className="h-5 w-5 text-primary" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="truncate text-lg font-semibold text-foreground">{viewer.name}</h3>
+              {viewer.active ? (
+                <Badge variant="success">Active</Badge>
+              ) : (
+                <Badge variant="secondary">
+                  Deactivated
+                  {viewer.deactivated_at ? ` ${formatRelativeTime(viewer.deactivated_at)}` : ''}
+                </Badge>
+              )}
+            </div>
+            <p className="mt-1 truncate text-xs text-muted-foreground" title={viewer.email}>
+              {viewer.email}
+            </p>
+          </div>
+        </div>
+
+        {/* Footer: added date + actions */}
+        <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
+          <time className="text-xs text-muted-foreground" dateTime={viewer.created_at || undefined}>
+            Added {formatRelativeTime(viewer.created_at)}
+          </time>
+          <div className="flex items-center gap-1">
+            {onToggleActive && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onToggleActive(viewer)}
+                disabled={isToggling}
+                data-testid={VIEWER_TEST_IDS.TOGGLE_ACTIVE_BUTTON}
+                aria-label={
+                  viewer.active
+                    ? `Deactivate viewer: ${viewer.name}`
+                    : `Reactivate viewer: ${viewer.name}`
+                }
+              >
+                {viewer.active ? (
+                  <>
+                    <UserRoundX className="mr-1 h-4 w-4" />
+                    Deactivate
+                  </>
+                ) : (
+                  <>
+                    <UserRoundCheck className="mr-1 h-4 w-4" />
+                    Reactivate
+                  </>
+                )}
+              </Button>
+            )}
+            {onEdit && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => onEdit(viewer)}
+                data-testid={VIEWER_TEST_IDS.EDIT_BUTTON}
+                aria-label={`Edit viewer: ${viewer.name}`}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            )}
+            {onDelete && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive hover:text-destructive"
+                onClick={() => onDelete(viewer)}
+                data-testid={VIEWER_TEST_IDS.DELETE_BUTTON}
+                aria-label={`Delete viewer: ${viewer.name}`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+});

--- a/src/components/viewers/ViewerForm.stories.tsx
+++ b/src/components/viewers/ViewerForm.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ViewerForm } from './ViewerForm';
+
+/**
+ * ViewerForm Component
+ *
+ * Create/edit form for read-only viewer accounts (D-27). Password is
+ * required on create (8-72 bytes) and optional on edit (blank keeps the
+ * current password).
+ */
+const meta = {
+  title: 'Viewers/ViewerForm',
+  component: ViewerForm,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  args: {
+    onSubmit: async () => {},
+    onCancel: () => {},
+    isLoading: false,
+    error: null,
+  },
+} satisfies Meta<typeof ViewerForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Create mode: password required
+ */
+export const Create: Story = {
+  args: {
+    mode: 'create',
+  },
+};
+
+/**
+ * Edit mode: seeded with existing values, blank password keeps the
+ * current one
+ */
+export const Edit: Story = {
+  args: {
+    mode: 'edit',
+    initialData: {
+      name: 'Alice',
+      email: 'alice@example.com',
+      password: '',
+    },
+  },
+};
+
+/**
+ * Submitting state
+ */
+export const Submitting: Story = {
+  args: {
+    mode: 'create',
+    isLoading: true,
+  },
+};
+
+/**
+ * With API error (e.g., duplicate email 409)
+ */
+export const WithError: Story = {
+  args: {
+    mode: 'create',
+    error: new Error('email already exists'),
+  },
+};

--- a/src/components/viewers/ViewerForm.tsx
+++ b/src/components/viewers/ViewerForm.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ErrorAlert } from '@/components/common/ErrorAlert';
+import { FormField } from '@/components/common/FormField';
+import { VIEWER_LIMITS, VIEWER_TEST_IDS } from '@/constants/viewer';
+import {
+  validateViewerForm,
+  type ViewerFormData,
+  type ViewerFormErrors,
+} from '@/utils/validation/viewerValidation';
+
+export interface ViewerFormProps {
+  /** Form mode: create (password required) or edit (password optional) */
+  mode: 'create' | 'edit';
+  /** Initial form data (for edit mode; password should be '') */
+  initialData?: ViewerFormData;
+  /**
+   * Callback when the form is submitted with valid data. In edit mode an
+   * empty password means "keep the current password" (the caller must omit
+   * the password key from the PUT body).
+   */
+  onSubmit: (data: ViewerFormData) => Promise<void>;
+  /** Whether a submission is in progress */
+  isLoading: boolean;
+  /** API error to display */
+  error: Error | null;
+  /** Callback when cancel button is clicked */
+  onCancel: () => void;
+}
+
+const defaultFormData: ViewerFormData = {
+  name: '',
+  email: '',
+  password: '',
+};
+
+/**
+ * ViewerForm - create/edit form for read-only viewer accounts (D-27).
+ *
+ * Name and email (the login identifier) are required. Password is required
+ * on create (8–72 bytes, set by the admin and shared out-of-band); on edit
+ * it is optional and blank keeps the current password.
+ */
+export function ViewerForm({
+  mode,
+  initialData,
+  onSubmit,
+  isLoading,
+  error,
+  onCancel,
+}: ViewerFormProps) {
+  const [formData, setFormData] = React.useState<ViewerFormData>(initialData || defaultFormData);
+  const [errors, setErrors] = React.useState<ViewerFormErrors>({});
+
+  const handleChange = (field: keyof ViewerFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleBlur = (field: keyof ViewerFormData) => {
+    const fieldErrors = validateViewerForm(formData, mode);
+    setErrors((prev) => ({ ...prev, [field]: fieldErrors[field] }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const newErrors = validateViewerForm(formData, mode);
+    setErrors(newErrors);
+
+    if (newErrors.name || newErrors.email || newErrors.password) {
+      return;
+    }
+
+    await onSubmit({
+      name: formData.name.trim(),
+      email: formData.email.trim(),
+      // Password is never trimmed: leading/trailing spaces are legal.
+      password: formData.password,
+    });
+  };
+
+  const submitButtonText = mode === 'create' ? 'Add Viewer' : 'Save Changes';
+  const loadingButtonText = mode === 'create' ? 'Adding...' : 'Saving...';
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <ErrorAlert error={error} />
+
+      {/* Name Field */}
+      <FormField label="Name" required htmlFor="viewer-name" error={errors.name}>
+        <Input
+          id="viewer-name"
+          data-testid={VIEWER_TEST_IDS.NAME_INPUT}
+          value={formData.name}
+          onChange={(e) => handleChange('name', e.target.value)}
+          onBlur={() => handleBlur('name')}
+          placeholder="e.g., Alice"
+          aria-required="true"
+          aria-invalid={!!errors.name}
+          disabled={isLoading}
+          maxLength={VIEWER_LIMITS.NAME_MAX_LENGTH}
+        />
+      </FormField>
+
+      {/* Email Field */}
+      <FormField label="Email" required htmlFor="viewer-email" error={errors.email}>
+        <Input
+          id="viewer-email"
+          type="email"
+          data-testid={VIEWER_TEST_IDS.EMAIL_INPUT}
+          value={formData.email}
+          onChange={(e) => handleChange('email', e.target.value)}
+          onBlur={() => handleBlur('email')}
+          placeholder="friend@example.com (used to log in)"
+          aria-required="true"
+          aria-invalid={!!errors.email}
+          disabled={isLoading}
+          maxLength={VIEWER_LIMITS.EMAIL_MAX_LENGTH}
+        />
+      </FormField>
+
+      {/* Password Field */}
+      <FormField
+        label={mode === 'create' ? 'Password' : 'New Password'}
+        required={mode === 'create'}
+        htmlFor="viewer-password"
+        error={errors.password}
+      >
+        <Input
+          id="viewer-password"
+          type="password"
+          autoComplete="new-password"
+          data-testid={VIEWER_TEST_IDS.PASSWORD_INPUT}
+          value={formData.password}
+          onChange={(e) => handleChange('password', e.target.value)}
+          onBlur={() => handleBlur('password')}
+          placeholder={
+            mode === 'create'
+              ? '8-72 bytes; share it with your friend yourself'
+              : 'Leave blank to keep the current password'
+          }
+          aria-required={mode === 'create'}
+          aria-invalid={!!errors.password}
+          disabled={isLoading}
+        />
+      </FormField>
+
+      {/* Action Buttons */}
+      <div className="flex justify-end gap-2 pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isLoading}
+          data-testid={VIEWER_TEST_IDS.CANCEL_BUTTON}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isLoading} data-testid={VIEWER_TEST_IDS.SAVE_BUTTON}>
+          {isLoading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {loadingButtonText}
+            </>
+          ) : (
+            submitButtonText
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/constants/viewer.ts
+++ b/src/constants/viewer.ts
@@ -1,0 +1,46 @@
+/**
+ * Viewer (read-only account, D-27) related constants
+ */
+
+/**
+ * Validation limits for viewer fields.
+ * Password bounds are BYTES (bcrypt limit), not characters.
+ */
+export const VIEWER_LIMITS = {
+  /** Maximum length for viewer name */
+  NAME_MAX_LENGTH: 255,
+  /** Maximum length for viewer email */
+  EMAIL_MAX_LENGTH: 255,
+  /** Minimum password length in bytes (backend validation) */
+  PASSWORD_MIN_BYTES: 8,
+  /** Maximum password length in bytes (bcrypt input limit) */
+  PASSWORD_MAX_BYTES: 72,
+} as const;
+
+/**
+ * Test IDs for viewer-related components
+ */
+export const VIEWER_TEST_IDS = {
+  /** Viewer card container */
+  CARD: 'viewer-card',
+  /** Name input field */
+  NAME_INPUT: 'viewer-name-input',
+  /** Email input field */
+  EMAIL_INPUT: 'viewer-email-input',
+  /** Password input field */
+  PASSWORD_INPUT: 'viewer-password-input',
+  /** Save button */
+  SAVE_BUTTON: 'viewer-save-button',
+  /** Cancel button */
+  CANCEL_BUTTON: 'viewer-cancel-button',
+  /** Edit button on a card */
+  EDIT_BUTTON: 'viewer-edit-button',
+  /** Activate/deactivate toggle button on a card */
+  TOGGLE_ACTIVE_BUTTON: 'viewer-toggle-active-button',
+  /** Delete button on a card */
+  DELETE_BUTTON: 'viewer-delete-button',
+  /** Delete confirmation dialog */
+  DELETE_DIALOG: 'viewer-delete-dialog',
+  /** Delete confirm button */
+  DELETE_CONFIRM_BUTTON: 'viewer-delete-confirm-button',
+} as const;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,11 +10,45 @@
 
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { login as loginApi, logout as logoutApi } from '@/lib/api/endpoints/auth';
+import { login as loginApi, logout as logoutApi, getMe } from '@/lib/api/endpoints/auth';
 import { clearCsrfToken } from '@/lib/security/CsrfTokenManager';
 import { logger } from '@/lib/logger';
+import type { Me, UserRole } from '@/types/api';
+
+/** React Query key for the GET /auth/me identity/role lookup. */
+const ME_QUERY_KEY = ['auth', 'me'] as const;
+
+/**
+ * Fetch the authenticated user's `{ sub, role }` via GET /auth/me (D-27 (5)).
+ *
+ * The role is intentionally NOT persisted anywhere (no localStorage): the
+ * server response is the single source of truth, and the backend enforces
+ * authorization on every call anyway. `role` is `undefined` while loading or
+ * when the request fails (callers should render the restrictive/read-only
+ * variant in that case).
+ */
+export function useMe(): {
+  me: Me | null;
+  role: UserRole | undefined;
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const query = useQuery({
+    queryKey: ME_QUERY_KEY,
+    queryFn: getMe,
+    staleTime: 60000,
+    retry: false, // 401/403 will not heal on retry
+  });
+
+  return {
+    me: query.data ?? null,
+    role: query.data?.role,
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+  };
+}
 
 /**
  * Authentication hook return type
@@ -68,19 +102,34 @@ interface UseAuthReturn {
  */
 export function useAuth(): UseAuthReturn {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   // Login mutation. On success the backend has already set the HttpOnly auth
   // cookie via Set-Cookie; we deliberately do NOT persist the body `token`
   // anywhere (localStorage / JS-readable cookie) — that is the H-1 fix.
   const loginMutation = useMutation({
     mutationFn: async ({ email, password }: { email: string; password: string }) => {
-      const response = await loginApi(email, password);
-      return response;
+      await loginApi(email, password);
+
+      // Ask the backend who we are (the cookie is HttpOnly, so GET /auth/me
+      // is the only way to learn the role — D-27 (5)). Best-effort: if it
+      // fails we fall back to the admin route and let the proxy sort a
+      // viewer out server-side.
+      let role: UserRole | undefined;
+      try {
+        const me = await getMe();
+        queryClient.setQueryData(ME_QUERY_KEY, me);
+        role = me.role;
+      } catch (error) {
+        logger.warn('GET /auth/me failed after login; defaulting to admin route', { error });
+      }
+      return role;
     },
-    onSuccess: () => {
+    onSuccess: (role) => {
       // Auth is now carried by the HttpOnly cookie the backend just set.
-      // Navigate to the dashboard; the proxy will read that cookie server-side.
-      router.push('/dashboard');
+      // Viewers only have access to /sources (D-27 (3)); admins keep the
+      // dashboard. The proxy re-enforces this server-side on every request.
+      router.push(role === 'viewer' ? '/sources' : '/dashboard');
       router.refresh();
     },
   });
@@ -114,6 +163,9 @@ export function useAuth(): UseAuthReturn {
 
     // Clear the client-side CSRF token (the JWT cookie is cleared server-side).
     clearCsrfToken();
+
+    // Drop the cached identity/role so the next session re-fetches it.
+    queryClient.removeQueries({ queryKey: ME_QUERY_KEY });
 
     // Purge any API responses the Service Worker cached while authenticated
     // (M-3). Sensitive endpoints are never cached, but this empties the whole

--- a/src/hooks/useViewers.ts
+++ b/src/hooks/useViewers.ts
@@ -1,0 +1,129 @@
+/**
+ * Viewer (read-only account, D-27) hooks
+ *
+ * React Query hooks for the admin-only viewer CRUD.
+ *
+ * Cache design:
+ * - ['viewers'] - list (single flat list; no per-viewer detail endpoint)
+ */
+
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getViewers,
+  createViewer,
+  updateViewer,
+  setViewerActive,
+  deleteViewer,
+} from '@/lib/api/endpoints/viewers';
+import type { ViewerCreateInput, ViewerUpdateInput } from '@/types/api';
+
+/**
+ * Fetch all viewers (active and deactivated).
+ */
+export function useViewers(options?: { enabled?: boolean }) {
+  const query = useQuery({
+    queryKey: ['viewers'],
+    queryFn: getViewers,
+    staleTime: 60000,
+    retry: 1,
+    enabled: options?.enabled ?? true,
+  });
+
+  return {
+    viewers: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+    refetch: () => {
+      query.refetch();
+    },
+  };
+}
+
+/**
+ * Create a viewer (name, email and initial password all required).
+ */
+export function useCreateViewer() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (input: ViewerCreateInput) => createViewer(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['viewers'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+    reset: mutation.reset,
+  };
+}
+
+/**
+ * Update a viewer's name/email; password only resets when provided.
+ */
+export function useUpdateViewer() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ id, input }: { id: number; input: ViewerUpdateInput }) =>
+      updateViewer(id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['viewers'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+    reset: mutation.reset,
+  };
+}
+
+/**
+ * Toggle a viewer's active state (logical deactivation — reversible,
+ * enforced on their next request without waiting for JWT expiry).
+ */
+export function useSetViewerActive() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ id, active }: { id: number; active: boolean }) => setViewerActive(id, active),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['viewers'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+    reset: mutation.reset,
+  };
+}
+
+/**
+ * Delete a viewer PERMANENTLY (physical delete — confirm with the user
+ * first; there is no undo).
+ */
+export function useDeleteViewer() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: number) => deleteViewer(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['viewers'] });
+    },
+  });
+
+  return {
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error as Error | null,
+    reset: mutation.reset,
+  };
+}

--- a/src/lib/api/endpoints/__tests__/auth.test.ts
+++ b/src/lib/api/endpoints/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { login, logout } from '../auth';
+import { login, logout, getMe } from '../auth';
 import { apiClient } from '@/lib/api/client';
 
 // Mock the API client
@@ -78,6 +78,23 @@ describe('Auth API Endpoints', () => {
       vi.mocked(apiClient.post).mockRejectedValue(new Error('network down'));
 
       await expect(logout()).rejects.toThrow('network down');
+    });
+  });
+
+  describe('getMe', () => {
+    it('calls GET /auth/me and returns sub + role (D-27)', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({ sub: 'friend@example.com', role: 'viewer' });
+
+      const result = await getMe();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/auth/me');
+      expect(result).toEqual({ sub: 'friend@example.com', role: 'viewer' });
+    });
+
+    it('propagates errors (401 unauthenticated / 403 deactivated viewer)', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('Forbidden'));
+
+      await expect(getMe()).rejects.toThrow('Forbidden');
     });
   });
 });

--- a/src/lib/api/endpoints/__tests__/viewers.test.ts
+++ b/src/lib/api/endpoints/__tests__/viewers.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getViewers, createViewer, updateViewer, setViewerActive, deleteViewer } from '../viewers';
+import { apiClient } from '@/lib/api/client';
+import { ApiError } from '@/lib/api/errors';
+import type { Viewer } from '@/types/api';
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockViewer: Viewer = {
+  id: 1,
+  name: 'Alice',
+  email: 'alice@example.com',
+  active: true,
+  created_at: '2026-07-01T09:00:00Z',
+  updated_at: '2026-07-01T09:00:00Z',
+  deactivated_at: null,
+};
+
+describe('Viewers API Endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getViewers', () => {
+    it('calls GET /viewers', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue([mockViewer]);
+
+      const result = await getViewers();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/viewers');
+      expect(result).toEqual([mockViewer]);
+    });
+
+    it('propagates API errors (403 for non-admin)', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new ApiError('Forbidden', 403));
+
+      await expect(getViewers()).rejects.toThrow('Forbidden');
+    });
+  });
+
+  describe('createViewer', () => {
+    it('calls POST /viewers with name, email and password', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue(mockViewer);
+
+      const input = { name: 'Alice', email: 'alice@example.com', password: 'correct-horse' };
+      const result = await createViewer(input);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/viewers', input);
+      expect(result).toEqual(mockViewer);
+    });
+
+    it('propagates duplicate email errors (409)', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new ApiError('email already exists', 409));
+
+      await expect(
+        createViewer({ name: 'Alice', email: 'alice@example.com', password: 'correct-horse' })
+      ).rejects.toThrow('email already exists');
+    });
+  });
+
+  describe('updateViewer', () => {
+    it('calls PUT /viewers/:id with the input body', async () => {
+      vi.mocked(apiClient.put).mockResolvedValue(mockViewer);
+
+      const input = { name: 'Alice', email: 'alice@example.com' };
+      const result = await updateViewer(1, input);
+
+      expect(apiClient.put).toHaveBeenCalledWith('/viewers/1', input);
+      expect(result).toEqual(mockViewer);
+    });
+
+    it('passes the optional password through when provided', async () => {
+      vi.mocked(apiClient.put).mockResolvedValue(mockViewer);
+
+      const input = { name: 'Alice', email: 'alice@example.com', password: 'new-password-123' };
+      await updateViewer(1, input);
+
+      expect(apiClient.put).toHaveBeenCalledWith('/viewers/1', input);
+    });
+  });
+
+  describe('setViewerActive', () => {
+    it('calls PUT /viewers/:id/active with {active: false} to deactivate', async () => {
+      const deactivated: Viewer = {
+        ...mockViewer,
+        active: false,
+        deactivated_at: '2026-07-19T00:00:00Z',
+      };
+      vi.mocked(apiClient.put).mockResolvedValue(deactivated);
+
+      const result = await setViewerActive(1, false);
+
+      expect(apiClient.put).toHaveBeenCalledWith('/viewers/1/active', { active: false });
+      expect(result).toEqual(deactivated);
+    });
+
+    it('calls PUT /viewers/:id/active with {active: true} to reactivate', async () => {
+      vi.mocked(apiClient.put).mockResolvedValue(mockViewer);
+
+      const result = await setViewerActive(1, true);
+
+      expect(apiClient.put).toHaveBeenCalledWith('/viewers/1/active', { active: true });
+      expect(result).toEqual(mockViewer);
+    });
+  });
+
+  describe('deleteViewer', () => {
+    it('calls DELETE /viewers/:id (physical delete)', async () => {
+      vi.mocked(apiClient.delete).mockResolvedValue(undefined);
+
+      await deleteViewer(1);
+
+      expect(apiClient.delete).toHaveBeenCalledWith('/viewers/1');
+    });
+
+    it('propagates API errors', async () => {
+      vi.mocked(apiClient.delete).mockRejectedValue(new ApiError('viewer not found', 404));
+
+      await expect(deleteViewer(999)).rejects.toThrow('viewer not found');
+    });
+  });
+});

--- a/src/lib/api/endpoints/auth.ts
+++ b/src/lib/api/endpoints/auth.ts
@@ -10,7 +10,7 @@
  */
 
 import { apiClient } from '@/lib/api/client';
-import type { LoginRequest, LoginResponse } from '@/types/api';
+import type { LoginRequest, LoginResponse, Me } from '@/types/api';
 
 /**
  * Login with email and password
@@ -54,4 +54,21 @@ export async function logout(): Promise<void> {
     requiresAuth: false, // Logout endpoint is idempotent and auth-optional
     retry: false,
   });
+}
+
+/**
+ * Fetch the authenticated user's identity and role (GET /auth/me).
+ *
+ * The JWT is in an HttpOnly cookie that JS cannot read (D-22), so this
+ * endpoint is the ONLY sanctioned way for the frontend to learn its role
+ * (`admin` / `viewer`, D-27 (5)). The role is never persisted client-side;
+ * display gating always re-derives it from this call (the backend enforces
+ * authorization regardless, so a spoofed role only breaks the spoofer's UI).
+ *
+ * @returns Promise resolving to `{ sub, role }`
+ * @throws {ApiError} 401 when unauthenticated, 403 for tokens without a
+ *   valid role or deactivated viewers
+ */
+export async function getMe(): Promise<Me> {
+  return apiClient.get<Me>('/auth/me');
 }

--- a/src/lib/api/endpoints/viewers.ts
+++ b/src/lib/api/endpoints/viewers.ts
@@ -1,0 +1,91 @@
+/**
+ * Viewers (read-only accounts, D-27) API Endpoints
+ *
+ * Admin-only CRUD for the `viewers` table: friend accounts that can log in
+ * to the dashboard and see the active source list, nothing else.
+ *
+ * Contract notes:
+ * - All endpoints are admin-only (viewer JWTs get 403).
+ * - POST /viewers requires name + email + password (8–72 bytes); the email
+ *   must be unique (409 on duplicates).
+ * - PUT /viewers/:id updates name/email; password is OPTIONAL and only
+ *   resets when the key is present — omit it to keep the current password.
+ * - PUT /viewers/:id/active toggles logical deactivation (deactivated_at
+ *   set/clear). Idempotent and reversible; deactivation takes effect on the
+ *   viewer's next request (DB re-check, no JWT-expiry wait — D-27 (4)).
+ * - DELETE /viewers/:id is a PHYSICAL delete (unlike subscribers). It
+ *   cannot be undone.
+ */
+
+import { apiClient } from '@/lib/api/client';
+import type { Viewer, ViewerCreateInput, ViewerUpdateInput } from '@/types/api';
+
+/**
+ * Fetch all viewers (active and deactivated)
+ *
+ * @returns Promise resolving to the viewers array
+ * @throws {ApiError} When the request fails (401, 403 non-admin)
+ */
+export async function getViewers(): Promise<Viewer[]> {
+  return apiClient.get<Viewer[]>('/viewers');
+}
+
+/**
+ * Create a new viewer account.
+ *
+ * @param input - name, email (login identifier, unique) and password
+ *   (8–72 bytes; the admin sets it and shares it out-of-band)
+ * @returns Promise resolving to the created viewer
+ * @throws {ApiError} When the request fails (400, 401, 403, 409 duplicate email)
+ */
+export async function createViewer(input: ViewerCreateInput): Promise<Viewer> {
+  return apiClient.post<Viewer>('/viewers', input);
+}
+
+/**
+ * Update a viewer's name / email, optionally resetting the password.
+ *
+ * Omit `password` (or pass undefined) to keep the current password; when
+ * present it must be 8–72 bytes.
+ *
+ * @param id - Viewer ID
+ * @param input - New name/email and optional new password
+ * @returns Promise resolving to the updated viewer
+ * @throws {ApiError} When the request fails (400, 401, 403, 404, 409 duplicate email)
+ */
+export async function updateViewer(id: number, input: ViewerUpdateInput): Promise<Viewer> {
+  return apiClient.put<Viewer>(`/viewers/${id}`, input);
+}
+
+/**
+ * Toggle a viewer's active state (logical deactivation, reversible).
+ *
+ * Deactivation is enforced on the viewer's next request via DB re-check —
+ * it does NOT wait for their JWT to expire (D-27 (4)).
+ *
+ * @param id - Viewer ID
+ * @param active - true to (re)activate, false to deactivate
+ * @returns Promise resolving to the toggled viewer
+ * @throws {ApiError} When the request fails (400, 401, 403, 404)
+ */
+export async function setViewerActive(id: number, active: boolean): Promise<Viewer> {
+  return apiClient.put<Viewer>(`/viewers/${id}/active`, { active });
+}
+
+/**
+ * Delete a viewer PERMANENTLY (physical delete, D-27 (4)).
+ *
+ * Unlike subscribers there is no soft-delete here: the row is removed and
+ * cannot be recovered. Their existing JWT stops working on the next request.
+ *
+ * @param id - Viewer ID
+ * @throws {ApiError} When the request fails (400, 401, 403, 404)
+ */
+export async function deleteViewer(id: number): Promise<void> {
+  await apiClient.delete(`/viewers/${id}`);
+}
+
+/**
+ * Export types for convenience
+ */
+export type { Viewer, ViewerCreateInput, ViewerUpdateInput };

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -722,6 +722,112 @@ describe('Proxy Function - CSRF Protection Integration Tests', () => {
     });
   });
 
+  describe('Viewer Role Routing (D-27)', () => {
+    const futureExp = () => Math.floor(Date.now() / 1000) + 3600;
+
+    it('redirects a viewer from /dashboard to /sources', async () => {
+      const request = new NextRequest('http://localhost:3000/dashboard', { method: 'GET' });
+      request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+      const { decodeJwt } = await import('jose');
+      vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp(), role: 'viewer' });
+
+      const response = proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toContain('/sources');
+    });
+
+    it.each(['/articles', '/subscribers', '/viewers', '/access-logs', '/books', '/learning'])(
+      'redirects a viewer from %s to /sources',
+      async (path) => {
+        const request = new NextRequest(`http://localhost:3000${path}`, { method: 'GET' });
+        request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+        const { decodeJwt } = await import('jose');
+        vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp(), role: 'viewer' });
+
+        const response = proxy(request);
+
+        expect(response.status).toBe(307);
+        expect(new URL(response.headers.get('location')!).pathname).toBe('/sources');
+      }
+    );
+
+    it('allows a viewer to access /sources', async () => {
+      const request = new NextRequest('http://localhost:3000/sources', { method: 'GET' });
+      request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+      const { decodeJwt } = await import('jose');
+      vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp(), role: 'viewer' });
+
+      const response = proxy(request);
+
+      expect(response.status).not.toBe(307);
+      expect(csrfUtils.setCsrfToken).toHaveBeenCalled();
+    });
+
+    it('does NOT let a viewer through on sibling paths like /sources-admin (boundary match)', async () => {
+      const request = new NextRequest('http://localhost:3000/sources-admin', { method: 'GET' });
+      request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+      const { decodeJwt } = await import('jose');
+      vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp(), role: 'viewer' });
+
+      const response = proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(new URL(response.headers.get('location')!).pathname).toBe('/sources');
+    });
+
+    it('redirects an authenticated viewer from /login to /sources (not /dashboard)', async () => {
+      const request = new NextRequest('http://localhost:3000/login', { method: 'GET' });
+      request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+      const { decodeJwt } = await import('jose');
+      vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp(), role: 'viewer' });
+
+      const response = proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(new URL(response.headers.get('location')!).pathname).toBe('/sources');
+    });
+
+    it('does not restrict admin-role tokens', async () => {
+      const request = new NextRequest('http://localhost:3000/viewers', { method: 'GET' });
+      request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+      const { decodeJwt } = await import('jose');
+      vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp(), role: 'admin' });
+
+      const response = proxy(request);
+
+      expect(response.status).not.toBe(307);
+    });
+
+    it('treats tokens WITHOUT a role claim as before (no viewer restriction)', async () => {
+      const request = new NextRequest('http://localhost:3000/dashboard', { method: 'GET' });
+      request.cookies.set('catchup_feed_auth_token', mockValidToken);
+
+      const { decodeJwt } = await import('jose');
+      vi.mocked(decodeJwt).mockReturnValue({ exp: futureExp() });
+
+      const response = proxy(request);
+
+      expect(response.status).not.toBe(307);
+    });
+
+    it('requires authentication for /viewers (redirects to login without a token)', () => {
+      const request = new NextRequest('http://localhost:3000/viewers', { method: 'GET' });
+
+      const response = proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toContain('/login');
+      expect(response.headers.get('location')).toContain('redirect=%2Fviewers');
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle POST request to public route (requires CSRF)', () => {
       // Arrange - POST to homepage (public route)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -42,7 +42,15 @@ const PROTECTED_ROUTES = [
   '/access-logs',
   '/books',
   '/learning',
+  '/viewers',
 ];
+
+/**
+ * The only protected route a `viewer` role may reach (D-27 (3)).
+ * Everything else redirects to it; the backend independently returns 403
+ * on every other API, so this is UX, not the security boundary.
+ */
+const VIEWER_HOME = '/sources';
 
 /**
  * Check if a path matches any of the protected routes
@@ -95,6 +103,26 @@ function isTokenValid(token: string): boolean {
 }
 
 /**
+ * Read the `role` claim from the JWT (D-27): 'admin' | 'viewer'.
+ *
+ * Like isTokenValid, this only decodes — no signature check. A forged role
+ * can at most change which pages the proxy serves; every API call is
+ * re-authorized by the backend. Tokens without a role claim (pre-D-27) are
+ * treated as before (admin-shaped routing; the backend still decides).
+ *
+ * @param token - JWT token string
+ * @returns the role claim, or null when absent/unreadable
+ */
+function getTokenRole(token: string): string | null {
+  try {
+    const { role } = decodeJwt(token);
+    return typeof role === 'string' ? role : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Next.js 16 Proxy Function
  *
  * Handles authentication, CSRF protection, and route access control.
@@ -142,8 +170,23 @@ export function proxy(request: NextRequest) {
       return response;
     }
 
-    // Login page: redirect to /dashboard if already authenticated with valid token
+    // Viewer role (D-27 (3)): the only protected route a viewer may open is
+    // /sources. Redirect everything else there server-side — hiding links in
+    // the UI alone is not an acceptable guarantee. The match is
+    // boundary-aware (exact or a `/`-separated child) so future sibling
+    // routes like `/sources-admin` do not slip through.
+    const isViewer = hasValidToken && token ? getTokenRole(token) === 'viewer' : false;
+    const isViewerAllowedPath = pathname === VIEWER_HOME || pathname.startsWith(`${VIEWER_HOME}/`);
+    if (isViewer && isProtectedRoute(pathname) && !isViewerAllowedPath) {
+      return NextResponse.redirect(new URL(VIEWER_HOME, request.url));
+    }
+
+    // Login page: redirect to /dashboard (viewers: /sources) if already
+    // authenticated with valid token
     if (pathname === '/login' && hasValidToken) {
+      if (isViewer) {
+        return NextResponse.redirect(new URL(VIEWER_HOME, request.url));
+      }
       // Check if there's a redirect parameter
       const redirectParam = request.nextUrl.searchParams.get('redirect');
       const dashboardUrl = new URL(redirectParam || '/dashboard', request.url);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -28,12 +28,22 @@ const API_CACHE_NAME = 'api-cache';
  * Path segments for authenticated, privacy-sensitive management endpoints
  * (M-3). Responses from these must never be written to the Service Worker
  * cache: they contain friend PII, feed tokens, access logs, learning data,
- * and the private book library (C-22). They are matched anywhere in the
- * pathname because the backend serves them without an `/api/` prefix
- * (e.g. `/subscribers`, `/tokens/:id`), and may also be reached through an
- * `/api/`-prefixed proxy.
+ * the private book library (C-22), viewer accounts (name + login email,
+ * D-27), and the caller's own identity (`/auth/me` returns an email in
+ * `sub`). They are matched anywhere in the pathname because the backend
+ * serves them without an `/api/` prefix (e.g. `/subscribers`,
+ * `/tokens/:id`), and may also be reached through an `/api/`-prefixed
+ * proxy.
  */
-const SENSITIVE_API_SEGMENTS = ['/subscribers', '/tokens', '/access-logs', '/learning', '/books'];
+const SENSITIVE_API_SEGMENTS = [
+  '/subscribers',
+  '/tokens',
+  '/access-logs',
+  '/learning',
+  '/books',
+  '/viewers',
+  '/auth/me',
+];
 
 /**
  * True when the request targets a sensitive management endpoint that must not

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -64,6 +64,19 @@ export interface TokenValidationResponse {
   email?: string;
 }
 
+/**
+ * Role carried by the JWT `role` claim (D-27): `admin` (single administrator,
+ * env credentials) or `viewer` (read-only friend account).
+ */
+export type UserRole = NonNullable<Schemas['internal_handler_http_auth.MeResponse']['role']>;
+
+/**
+ * Response of GET /auth/me. The JWT lives in an HttpOnly cookie (D-22), so
+ * this endpoint is the only way for client code to learn its own role
+ * (D-27 (5)).
+ */
+export type Me = Full<Schemas['internal_handler_http_auth.MeResponse']>;
+
 // ============================================================================
 // Article Types
 // ============================================================================
@@ -248,6 +261,33 @@ export type IssuedFeedToken = Nullable<
  * Response of DELETE /tokens/:id (revocation is irreversible).
  */
 export type RevokedFeedToken = Full<Schemas['internal_handler_http_subscriber.RevokedTokenDTO']>;
+
+// ============================================================================
+// Viewer (read-only account) Types — D-27
+// ============================================================================
+
+/**
+ * Viewer (read-only friend account) entity.
+ * `deactivated_at` set = logically deactivated (reversible via
+ * PUT /viewers/:id/active). Deletion, unlike subscribers, is PHYSICAL.
+ */
+export type Viewer = Nullable<Schemas['internal_handler_http_viewer.DTO'], 'deactivated_at'>;
+
+/**
+ * Body of POST /viewers. All three fields are required; the admin sets the
+ * initial password (8–72 bytes, bcrypt'd server-side).
+ */
+export type ViewerCreateInput = Full<Schemas['internal_handler_http_viewer.CreateRequest']>;
+
+/**
+ * Body of PUT /viewers/:id. name / email are required; password is optional
+ * and only resets the password when present (omit the key to keep the
+ * current password).
+ */
+export type ViewerUpdateInput = Full<
+  Omit<Schemas['internal_handler_http_viewer.UpdateRequest'], 'password'>
+> &
+  Pick<Schemas['internal_handler_http_viewer.UpdateRequest'], 'password'>;
 
 // ============================================================================
 // Access Log Types

--- a/src/types/generated/api.d.ts
+++ b/src/types/generated/api.d.ts
@@ -562,6 +562,65 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 認証情報取得
+         * @description 認証済みユーザーの識別子(sub)とロール(admin / viewer)を返します。
+         *     JWT は HttpOnly cookie のため JS から読めず、frontend が自分のロールを
+         *     知る唯一の手段です(D-27 (5)、D-22)。admin / viewer の両ロールが呼べます。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 認証済みユーザーの sub と role */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_auth.MeResponse"];
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - role クレームなし・未知 role・無効化済み viewer */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/token": {
         parameters: {
             query?: never;
@@ -573,7 +632,10 @@ export interface paths {
         put?: never;
         /**
          * JWT トークン取得
-         * @description 管理者のユーザー名とパスワードで認証し、JWT トークンを発行します。
+         * @description メールアドレスとパスワードで認証し、JWT トークンを発行します。
+         *     まず管理者(環境変数+bcrypt)と照合し、不一致なら viewers テーブルの
+         *     アクティブな閲覧専用アカウントと照合します(D-27。無効化済み viewer は拒否)。
+         *     発行する JWT には role クレーム(admin / viewer)が入ります。
          *     JSON body の token(dev の Bearer フォールバック用に後方互換で維持)に加え、
          *     同じ JWT を HttpOnly / Secure / SameSite=Strict の cookie
          *     (catchup_feed_auth_token)で Set-Cookie します(D-22)。
@@ -1333,7 +1395,8 @@ export interface paths {
         };
         /**
          * ソース一覧取得
-         * @description 登録されているすべてのソースを取得します
+         * @description 登録されているソースを取得します。admin はアクティブ・非アクティブ含む全件、
+         *     viewer はアクティブなソースのみ返ります(サーバー側で強制フィルタ、D-27)
          */
         get: {
             parameters: {
@@ -1434,7 +1497,7 @@ export interface paths {
         };
         /**
          * ソース検索
-         * @description マルチキーワードでソースを検索します（AND論理）
+         * @description マルチキーワードでソースを検索します（AND論理）。admin 専用(viewer は 403、D-27)
          */
         get: {
             parameters: {
@@ -1472,6 +1535,15 @@ export interface paths {
                 };
                 /** @description Authentication required */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - viewer ロールは検索不可(D-27) */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -2111,6 +2183,378 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/viewers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * viewer 一覧取得
+         * @description 閲覧専用アカウント(viewer, D-27)をアクティブ・非アクティブ含めてすべて取得します。
+         *     active / deactivated_at で有効・無効を判別できます。admin 専用
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description viewer 一覧 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_viewer.DTO"][];
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - admin 専用 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * viewer 登録
+         * @description 閲覧専用アカウントを作成します。パスワードは admin が設定し(D-27 (2))、
+         *     サーバー側で bcrypt ハッシュのみ保存されます。admin 専用
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description viewer 情報(name / email / password すべて必須) */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler_http_viewer.CreateRequest"];
+                };
+            };
+            responses: {
+                /** @description 作成された viewer */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_viewer.DTO"];
+                    };
+                };
+                /** @description Bad request - name/email/password が不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - admin 専用 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Conflict - email が既に登録済み */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/viewers/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * viewer 更新
+         * @description viewer の name / email を更新します。password は任意で、指定した場合のみ
+         *     再設定されます(省略時は現在のパスワードを維持)。admin 専用
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description viewer ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description 更新する viewer 情報 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler_http_viewer.UpdateRequest"];
+                };
+            };
+            responses: {
+                /** @description 更新後の viewer */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_viewer.DTO"];
+                    };
+                };
+                /** @description Bad request - 入力が不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - admin 専用 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - viewer が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Conflict - email が既に登録済み */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * viewer 削除(物理削除)
+         * @description viewer を物理削除します(subscribers と異なり集計のために行を残す理由が
+         *     ないため、D-27 (4))。削除後、その viewer の既存 JWT はリクエスト時の
+         *     DB 再検証で即座に 403 になります。admin 専用
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description viewer ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad request - invalid ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - admin 専用 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - viewer が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/viewers/{id}/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * viewer 有効/無効切替
+         * @description viewer の有効/無効を切り替えます(論理無効化 = deactivated_at の set/clear)。
+         *     無効化はリクエスト時の DB 再検証により即時反映され、発行済み JWT の失効を
+         *     待ちません(D-27 (4))。冪等。admin 専用
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description viewer ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description {active: true|false} */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler_http_viewer.ActiveRequest"];
+                };
+            };
+            responses: {
+                /** @description 切替後の viewer */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler_http_viewer.DTO"];
+                    };
+                };
+                /** @description Bad request - 入力が不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden - admin 専用 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - viewer が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2205,6 +2649,15 @@ export interface components {
             title?: string;
             /** @example https://example.com/article/1 */
             url?: string;
+        };
+        "internal_handler_http_auth.MeResponse": {
+            /**
+             * @example viewer
+             * @enum {string}
+             */
+            role?: "admin" | "viewer";
+            /** @example friend@example.com */
+            sub?: string;
         };
         "internal_handler_http_auth.loginRequest": {
             /** @example admin@example.com */
@@ -2441,6 +2894,35 @@ export interface components {
             id?: number;
             revoked_at?: string;
             subscriber_id?: number;
+        };
+        "internal_handler_http_viewer.ActiveRequest": {
+            /** @example false */
+            active?: boolean;
+        };
+        "internal_handler_http_viewer.CreateRequest": {
+            /** @example alice@example.com */
+            email?: string;
+            /** @example Alice */
+            name?: string;
+            /** @example correct-horse-battery */
+            password?: string;
+        };
+        "internal_handler_http_viewer.DTO": {
+            active?: boolean;
+            created_at?: string;
+            deactivated_at?: string;
+            email?: string;
+            id?: number;
+            name?: string;
+            updated_at?: string;
+        };
+        "internal_handler_http_viewer.UpdateRequest": {
+            /** @example alice@example.com */
+            email?: string;
+            /** @example Alice */
+            name?: string;
+            /** @example new-password-123 */
+            password?: string;
         };
     };
     responses: never;

--- a/src/utils/validation/viewerValidation.test.ts
+++ b/src/utils/validation/viewerValidation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateViewerName,
+  validateViewerEmail,
+  validateViewerPassword,
+  validateViewerForm,
+} from './viewerValidation';
+import { VIEWER_LIMITS } from '@/constants/viewer';
+
+describe('validateViewerName', () => {
+  it('accepts a normal name', () => {
+    expect(validateViewerName('Alice')).toBeUndefined();
+  });
+
+  it('rejects empty and whitespace-only names', () => {
+    expect(validateViewerName('')).toBe('Name is required');
+    expect(validateViewerName('   ')).toBe('Name is required');
+  });
+
+  it('rejects names over the max length', () => {
+    const long = 'a'.repeat(VIEWER_LIMITS.NAME_MAX_LENGTH + 1);
+    expect(validateViewerName(long)).toContain('Maximum');
+  });
+});
+
+describe('validateViewerEmail', () => {
+  it('rejects empty (email is the login identifier and required)', () => {
+    expect(validateViewerEmail('')).toBe('Email is required');
+  });
+
+  it('accepts a valid email', () => {
+    expect(validateViewerEmail('alice@example.com')).toBeUndefined();
+  });
+
+  it('rejects malformed emails', () => {
+    expect(validateViewerEmail('not-an-email')).toBe('Please enter a valid email address');
+    expect(validateViewerEmail('a@b')).toBe('Please enter a valid email address');
+  });
+
+  it('rejects emails over the max length', () => {
+    const long = `${'a'.repeat(VIEWER_LIMITS.EMAIL_MAX_LENGTH)}@example.com`;
+    expect(validateViewerEmail(long)).toContain('Maximum');
+  });
+});
+
+describe('validateViewerPassword', () => {
+  it('requires a password in create mode', () => {
+    expect(validateViewerPassword('', { required: true })).toBe('Password is required');
+  });
+
+  it('allows blank in edit mode (keep current password)', () => {
+    expect(validateViewerPassword('', { required: false })).toBeUndefined();
+  });
+
+  it('accepts a password within the byte bounds', () => {
+    expect(validateViewerPassword('correct-horse', { required: true })).toBeUndefined();
+  });
+
+  it('rejects passwords under the minimum bytes', () => {
+    expect(validateViewerPassword('short12', { required: true })).toContain('at least');
+  });
+
+  it('rejects passwords over the maximum bytes', () => {
+    const long = 'a'.repeat(VIEWER_LIMITS.PASSWORD_MAX_BYTES + 1);
+    expect(validateViewerPassword(long, { required: true })).toContain('at most');
+  });
+
+  it('measures length in UTF-8 BYTES, not characters (bcrypt limit)', () => {
+    // 3 multibyte chars (3 bytes each in UTF-8) = 9 bytes >= 8: valid
+    expect(validateViewerPassword('あいう', { required: true })).toBeUndefined();
+    // 24 chars x 3 bytes = 72 bytes: exactly at the limit
+    expect(validateViewerPassword('あ'.repeat(24), { required: true })).toBeUndefined();
+    // 25 chars x 3 bytes = 75 bytes: over the limit despite only 25 chars
+    expect(validateViewerPassword('あ'.repeat(25), { required: true })).toContain('at most');
+  });
+});
+
+describe('validateViewerForm', () => {
+  it('returns an empty object for valid create data', () => {
+    expect(
+      validateViewerForm(
+        { name: 'Alice', email: 'alice@example.com', password: 'correct-horse' },
+        'create'
+      )
+    ).toEqual({});
+  });
+
+  it('allows blank password in edit mode', () => {
+    expect(
+      validateViewerForm({ name: 'Alice', email: 'alice@example.com', password: '' }, 'edit')
+    ).toEqual({});
+  });
+
+  it('collects errors per field', () => {
+    const errors = validateViewerForm({ name: '', email: 'bad', password: '' }, 'create');
+    expect(errors.name).toBe('Name is required');
+    expect(errors.email).toBe('Please enter a valid email address');
+    expect(errors.password).toBe('Password is required');
+  });
+});

--- a/src/utils/validation/viewerValidation.ts
+++ b/src/utils/validation/viewerValidation.ts
@@ -1,0 +1,117 @@
+/**
+ * Viewer (read-only account, D-27) form validation
+ *
+ * Name and email are always required (email is the login identifier).
+ * Password is required when creating; optional when editing (blank = keep
+ * the current password). Password bounds are BYTES (bcrypt limit).
+ */
+
+import { VIEWER_LIMITS } from '@/constants/viewer';
+
+/**
+ * Form data for viewer create/edit
+ */
+export interface ViewerFormData {
+  name: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Validation errors keyed by field
+ */
+export interface ViewerFormErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+}
+
+/** Minimal email shape check (backend performs authoritative validation) */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validate the viewer name (required, max length)
+ */
+export function validateViewerName(name: string): string | undefined {
+  if (!name || name.trim().length === 0) {
+    return 'Name is required';
+  }
+  if (name.length > VIEWER_LIMITS.NAME_MAX_LENGTH) {
+    return `Maximum ${VIEWER_LIMITS.NAME_MAX_LENGTH} characters allowed`;
+  }
+  return undefined;
+}
+
+/**
+ * Validate the viewer email (required — it is the login identifier)
+ */
+export function validateViewerEmail(email: string): string | undefined {
+  if (!email || email.trim().length === 0) {
+    return 'Email is required';
+  }
+  if (email.length > VIEWER_LIMITS.EMAIL_MAX_LENGTH) {
+    return `Maximum ${VIEWER_LIMITS.EMAIL_MAX_LENGTH} characters allowed`;
+  }
+  if (!EMAIL_PATTERN.test(email.trim())) {
+    return 'Please enter a valid email address';
+  }
+  return undefined;
+}
+
+/**
+ * Validate the viewer password.
+ *
+ * The backend bounds are in BYTES (8–72, the bcrypt input limit), so the
+ * length is measured after UTF-8 encoding — multibyte characters count as
+ * more than one.
+ *
+ * @param password - Raw password input
+ * @param options.required - true for create mode; false for edit mode,
+ *   where an empty password means "keep the current password"
+ */
+export function validateViewerPassword(
+  password: string,
+  options: { required: boolean }
+): string | undefined {
+  if (!password || password.length === 0) {
+    return options.required ? 'Password is required' : undefined;
+  }
+  const bytes = new TextEncoder().encode(password).length;
+  if (bytes < VIEWER_LIMITS.PASSWORD_MIN_BYTES) {
+    return `Password must be at least ${VIEWER_LIMITS.PASSWORD_MIN_BYTES} bytes`;
+  }
+  if (bytes > VIEWER_LIMITS.PASSWORD_MAX_BYTES) {
+    return `Password must be at most ${VIEWER_LIMITS.PASSWORD_MAX_BYTES} bytes`;
+  }
+  return undefined;
+}
+
+/**
+ * Validate the whole form; returns an empty object when valid.
+ *
+ * @param data - Current form values
+ * @param mode - 'create' requires a password; 'edit' allows leaving it blank
+ */
+export function validateViewerForm(
+  data: ViewerFormData,
+  mode: 'create' | 'edit'
+): ViewerFormErrors {
+  const errors: ViewerFormErrors = {};
+
+  const nameError = validateViewerName(data.name);
+  if (nameError) {
+    errors.name = nameError;
+  }
+
+  const emailError = validateViewerEmail(data.email);
+  if (emailError) {
+    errors.email = emailError;
+  }
+
+  const passwordError = validateViewerPassword(data.password, { required: mode === 'create' });
+  if (passwordError) {
+    errors.password = passwordError;
+  }
+
+  return errors;
+}

--- a/tests/e2e/support/api-mock.ts
+++ b/tests/e2e/support/api-mock.ts
@@ -167,6 +167,12 @@ export class ApiMock {
       }
       return;
     }
+    if (method === 'GET' && path === '/auth/me') {
+      // e2e sessions are always the admin (D-27): the sources page and the
+      // header derive their role-scoped UI from this endpoint.
+      await this.fulfillJson(route, { sub: TEST_CREDENTIALS.email, role: 'admin' });
+      return;
+    }
     if (method === 'POST' && path === '/auth/logout') {
       // The real backend clears the auth cookie on logout; mirror that by
       // removing it from the app origin. Respond 204 like the real handler.

--- a/tests/e2e/support/auth.ts
+++ b/tests/e2e/support/auth.ts
@@ -33,6 +33,9 @@ export function makeMockJwt(expiresInSeconds = 60 * 60): string {
   const payload = {
     sub: 'admin',
     email: TEST_CREDENTIALS.email,
+    // Role claim (D-27): the proxy routes viewer-role tokens to /sources
+    // only, so the admin e2e session must carry an explicit admin role.
+    role: 'admin',
     exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
   };
   return `${base64url(header)}.${base64url(payload)}.e2e-mock-signature`;


### PR DESCRIPTION
## 目的

D-27「友人向け閲覧専用アカウント(viewer)」の frontend 実装。友人がソース一覧を眺めて「いる・いらない・これ追加したら」の意見をくれる導線を作る。**backend PR #96(catchup-feed リポジトリ)とペア**であり、API 契約は backend の Swagger を正とする(C-19)。

## 主な変更点

- **role 取得(useMe / GET /auth/me)**: JWT は HttpOnly cookie(D-22)で JS から読めないため、`GET /auth/me` を role の唯一の情報源とする `useMe` フックを追加。role は localStorage 等に永続化しない。ログイン成功後は viewer → `/sources`、admin → `/dashboard` に分岐
- **proxy による viewer の /sources 閉じ込め**: JWT の `role` クレームを読み、viewer は `/sources`(境界付き一致)以外の保護ルートをサーバー側で `/sources` へ 307。`/viewers` を保護ルートに追加。role クレームなしの旧トークンは従来挙動(backend が最終判定)
- **/sources の閲覧専用化**: viewer には Add Source・検索/フィルタ(viewer は 403)・編集/削除/トグル・各ダイアログを出さず、SourceCard を閲覧専用(StatusBadge)で描画。admin の挙動は不変
- **/viewers 管理画面(admin 専用、新規)**: 一覧(active/deactivated カウント+判別表示)、作成(name/email/password)、編集(password は任意再設定・空欄で維持)、有効/無効トグル(可逆・確認なし)、物理削除(「完全に削除・復元不可」を明示する確認ダイアログ)。Storybook ストーリー付き
- **Header の role 出し分け**: admin は全ナビ+`Viewers`、viewer は `Sources` のみ。Logout は両ロールに表示(POST /auth/logout は公開)。role 未確定中はメインナビ非表示(admin リンクのフラッシュ防止)
- **Service Worker の never-cache 追加(M-3)**: `SENSITIVE_API_SEGMENTS` に `/viewers`(友人 PII)と `/auth/me`(sub にメール)を追加
- 型は `npm run generate:api` で backend Swagger から再生成。新規エンドポイント/バリデーション/proxy ルーティング/閲覧専用 /sources のユニットテスト追加、e2e モックに role クレームと /auth/me を追加

## レビュー

code-reviewer レビュー済み。blocking 1件(SW の `/viewers` never-cache 漏れ)は解消済み。non-blocking 指摘(`/auth/me` の never-cache、viewer 許可判定の境界付き一致)も対応済み。

## 検証

- `npm run lint`(max-warnings 0): pass
- `npx tsc --noEmit`: pass
- `npx vitest run`: 78 files / 1641 passed, 1 skipped
- `npm run build`(webpack、D-23 により --turbopack 不使用): 成功、`/viewers` ルート生成確認

## デプロイ順

**backend #96 を先にデプロイすること。** 本 PR は `GET /auth/me` と `/viewers` 系 API に依存するため、frontend が先に出ると admin の role 取得に失敗しナビ/管理 UI が表示されない。