### PR TITLE
feat: ソース種別に newsletter を追加

### DIFF
--- a/src/components/sources/SourceCard.test.tsx
+++ b/src/components/sources/SourceCard.test.tsx
@@ -74,6 +74,12 @@ describe('SourceCard', () => {
       expect(screen.getByTestId('source-kind-badge')).toHaveTextContent('RSS');
     });
 
+    it('should render the Newsletter kind badge for newsletter sources', () => {
+      const source = createMockSource({ kind: 'newsletter' });
+      render(<SourceCard source={source} />);
+      expect(screen.getByTestId('source-kind-badge')).toHaveTextContent('Newsletter');
+    });
+
     it('should not render language badge when lang is empty', () => {
       const source = createMockSource({ lang: '' });
       render(<SourceCard source={source} />);

--- a/src/components/sources/SourceCard.tsx
+++ b/src/components/sources/SourceCard.tsx
@@ -15,7 +15,7 @@
  * always render management controls, so there is no role branching here.
  */
 import * as React from 'react';
-import { Rss, Tv, Podcast, Pencil, Trash2, type LucideIcon } from 'lucide-react';
+import { Rss, Tv, Podcast, Newspaper, Pencil, Trash2, type LucideIcon } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -35,6 +35,7 @@ const KIND_META: Record<SourceKind, { label: string; Icon: LucideIcon }> = {
   rss: { label: 'RSS', Icon: Rss },
   youtube: { label: 'YouTube', Icon: Tv },
   podcast: { label: 'Podcast', Icon: Podcast },
+  newsletter: { label: 'Newsletter', Icon: Newspaper },
 };
 
 /**

--- a/src/components/sources/SourceForm.test.tsx
+++ b/src/components/sources/SourceForm.test.tsx
@@ -409,6 +409,35 @@ describe('SourceForm', () => {
       });
     });
 
+    it('should submit the newsletter kind when selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <SourceForm
+          mode="create"
+          onSubmit={mockOnSubmit}
+          isLoading={false}
+          error={null}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await user.type(screen.getByLabelText('Source name'), 'Weekly Links');
+      await user.type(screen.getByLabelText('Feed URL'), 'https://newsletter.example.com/rss');
+      await user.type(screen.getByLabelText('Category'), 'tech');
+      await user.selectOptions(screen.getByLabelText('Source type'), 'newsletter');
+      await user.click(screen.getByRole('button', { name: /add source/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith({
+          kind: 'newsletter',
+          name: 'Weekly Links',
+          feedURL: 'https://newsletter.example.com/rss',
+          category: 'tech',
+          lang: '',
+        });
+      });
+    });
+
     it('should pre-select the kind from initialData in edit mode', () => {
       render(
         <SourceForm

--- a/src/components/sources/SourceForm.tsx
+++ b/src/components/sources/SourceForm.tsx
@@ -32,6 +32,7 @@ const KIND_OPTIONS: ReadonlyArray<{ value: SourceKind; label: string }> = [
   { value: 'rss', label: 'RSS' },
   { value: 'youtube', label: 'YouTube' },
   { value: 'podcast', label: 'Podcast' },
+  { value: 'newsletter', label: 'Newsletter' },
 ];
 
 /**

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -136,7 +136,8 @@ export type ArticleResponse = Article;
 
 /**
  * Source kind: how the source is ingested (Phase 2 multi-modal).
- * 'rss' = regular RSS/Atom feed, 'youtube' / 'podcast' = transcription path.
+ * 'rss' = regular RSS/Atom feed, 'youtube' / 'podcast' = transcription path,
+ * 'newsletter' = link-roundup newsletter (issue links expanded into articles).
  */
 export type SourceKind = NonNullable<Schemas['internal_handler_http_source.DTO']['kind']>;
 
@@ -194,7 +195,7 @@ export interface SourceFormData {
   category: string;
   /** Content language (optional) */
   lang: string;
-  /** Source kind (rss / youtube / podcast; defaults to 'rss') */
+  /** Source kind (rss / youtube / podcast / newsletter; defaults to 'rss') */
   kind: SourceKind;
 }
 

--- a/src/types/generated/api.d.ts
+++ b/src/types/generated/api.d.ts
@@ -1647,7 +1647,7 @@ export interface paths {
         post?: never;
         /**
          * ソース削除
-         * @description ソースを削除します
+         * @description ソースを削除します(論理削除。記事は保持されます)
          */
         delete: {
             parameters: {
@@ -1679,6 +1679,15 @@ export interface paths {
                 };
                 /** @description Authentication required - missing or invalid JWT token */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["catchup-feed_internal_handler_http_respond.ErrorResponse"];
+                    };
+                };
+                /** @description Not found - source not found */
+                404: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -2813,7 +2822,7 @@ export interface components {
              * @example rss
              * @enum {string}
              */
-            kind?: "rss" | "youtube" | "podcast";
+            kind?: "rss" | "youtube" | "podcast" | "newsletter";
             /** @example en */
             lang?: string;
             /** @example Go Blog */
@@ -2829,7 +2838,7 @@ export interface components {
              * @example rss
              * @enum {string}
              */
-            kind?: "rss" | "youtube" | "podcast";
+            kind?: "rss" | "youtube" | "podcast" | "newsletter";
             lang?: string;
             name?: string;
             /** @description Mapped from FeedURL for frontend compatibility */
@@ -2846,7 +2855,7 @@ export interface components {
              * @example rss
              * @enum {string}
              */
-            kind?: "rss" | "youtube" | "podcast";
+            kind?: "rss" | "youtube" | "podcast" | "newsletter";
             /** @example en */
             lang?: string;
             /** @example Go Blog */

--- a/src/utils/validation/sourceValidation.ts
+++ b/src/utils/validation/sourceValidation.ts
@@ -25,7 +25,7 @@ export interface SourceFormData {
   /** Content language (optional, e.g. "ja", "en") */
   lang: string;
   /**
-   * Source kind (rss / youtube / podcast; defaults to 'rss').
+   * Source kind (rss / youtube / podcast / newsletter; defaults to 'rss').
    * Constrained by a select, so it needs no validation.
    */
   kind: SourceKind;


### PR DESCRIPTION
## 概要

backend #101 で `sources.kind` に第4の値 `newsletter`(リンク集型ニュースレター。号内リンクを展開して個別記事として要約する)が追加されたため、フロントエンドを追随させる。

## 変更内容

- 確定 Swagger から `src/types/generated/api.d.ts` を再生成
  - kind の enum 3箇所(DTO / CreateRequest / UpdateRequest)に `newsletter` を追加
  - DELETE /sources/:id の 404 レスポンス定義と説明文の更新も取り込み
- ソース作成・編集フォーム(SourceForm)の種別選択肢に「Newsletter」を追加
- ソースカード(SourceCard)の kind バッジに Newsletter(Newspaper アイコン)を追加
  - viewer(閲覧専用 role)のソース一覧は同じ SourceCard を使うため、追加対応なしで表示される
- kind を列挙している型コメント・バリデーションコメントを更新
- newsletter の選択・送信・バッジ表示のテストを追加

## 検証

- `npx tsc --noEmit` 通過(KIND_META は `Record<SourceKind, ...>` のため網羅性も型で担保)
- `npm run lint`(max-warnings 0)通過
- `npm run test` 79 files / 1646 passed
- `npm run build`(webpack)通過

## デプロイ順序

backend #101 のマージ・デプロイ後に有効になる。本 PR を先にマージしても、newsletter 選択時に backend が 400 を返すだけで既存機能には影響しない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Newsletter as a selectable source type.
  * Newsletter sources now display a dedicated icon and “Newsletter” badge.
  * Newsletter setup supports name, RSS URL, category, and language fields.

* **Tests**
  * Added coverage for newsletter source display and form submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->