### PR TITLE
fix: 記事詳細と左レールから API 未提供のプレースホルダ領域を削除

### DIFF
--- a/src/app/(protected)/articles/[id]/page.tsx
+++ b/src/app/(protected)/articles/[id]/page.tsx
@@ -10,9 +10,29 @@ import { safeExternalHref } from '@/lib/utils/safeExternalHref';
 /**
  * Article Detail — 放送卓(改訂版) §4
  *
- * One article's summary, where it airs in the episode, and when it will be
- * re-asked. Episode / segment / script / quiz data has no backend API yet:
- * those regions render hairline frames with `—` (README ローディング spec).
+ * One article's title, source and AI summary, as a single reading column.
+ * The design's right sidebar (読み上げ台本 / 出題 / 同じ回), the status band's
+ * `← 前の記事` / `次の記事 →`, and the breadcrumb's episode slot are
+ * permanently removed (D-38). Each region had its own reason:
+ *
+ * - 読み上げ台本 / 同じ回 / breadcrumb episode slot ("EP 218 に収録済"): no API
+ *   links an article to an episode or its segments (the generated types expose
+ *   no `/episodes` path), and adding a backend endpoint just for this screen is
+ *   not right-sized. The breadcrumb slot outlived the other two by a day and
+ *   was dropped 2026-08-13 to keep the class consistent — the breadcrumb is now
+ *   the 記事 link alone.
+ * - 前後記事: no adjacency API. Faking it with the list's pagination endpoint
+ *   would drag the list's filter and sort state into this page — complexity
+ *   out of proportion to the value.
+ * - 出題: this one was implementable — `GET /learning/items` already returns
+ *   `article_id` / `question` / `stage` / `due_on`. It was dropped by product
+ *   decision (2026-08-12), not for lack of an API: quizzes belong to
+ *   `/learning`, and this page stays a place to read the summary.
+ *
+ * One placeholder is left on purpose: `本文抽出 —` in the footer. The article
+ * DTO carries no extracted-body length, but the rest of that line is live data
+ * (要約字数 / 取得時刻), so the line stays whole with one field degraded rather
+ * than being dropped (D-38).
  *
  * No audio player here (D-35): per-article audio files are never generated,
  * and episode audio is delivered by the podcast app, not this dashboard.
@@ -46,39 +66,16 @@ export default function ArticleDetailPage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      {/* Status band: breadcrumb + prev/next (episode linkage API pending) */}
+      {/* Status band (58px): breadcrumb only. README §4 was revised with D-38
+          to put nothing on the right — this matches the design, not a drift. */}
       <div className="flex h-[58px] shrink-0 items-center justify-between border-b border-console-line-2 bg-console-band px-5 sm:px-8">
-        <div className="flex min-w-0 items-center gap-2 font-mono text-[11.5px]">
-          <Link
-            href="/articles"
-            className="shrink-0 text-console-ink-weak transition-colors duration-[120ms] ease-out hover:text-console-ink hover:underline"
-          >
-            <span className="sm:hidden">← 記事</span>
-            <span className="hidden sm:inline">記事</span>
-          </Link>
-          <span aria-hidden className="text-console-ink-faint">
-            ／
-          </span>
-          <span className="truncate text-console-cyan">—</span>
-        </div>
-        <div className="hidden shrink-0 gap-2 sm:flex">
-          <button
-            type="button"
-            disabled
-            title="番組 API 未接続のため使用できません"
-            className="border border-console-line-3 px-3 py-1.5 font-mono text-[11px] text-console-ink-weak disabled:opacity-60"
-          >
-            ← 前の記事
-          </button>
-          <button
-            type="button"
-            disabled
-            title="番組 API 未接続のため使用できません"
-            className="border border-console-line-3 px-3 py-1.5 font-mono text-[11px] text-console-ink-weak disabled:opacity-60"
-          >
-            次の記事 →
-          </button>
-        </div>
+        <Link
+          href="/articles"
+          className="flex h-full items-center font-mono text-[11.5px] text-console-ink-weak transition-colors duration-[120ms] ease-out hover:text-console-ink hover:underline"
+        >
+          <span className="sm:hidden">← 記事</span>
+          <span className="hidden sm:inline">記事</span>
+        </Link>
       </div>
 
       {/* Error / not-found states, kept quiet (縮退許容 — no alarm red) */}
@@ -106,84 +103,57 @@ export default function ArticleDetailPage() {
         </div>
       )}
 
+      {/* Single reading column: capped at 720px so long summaries keep a
+          readable measure, left-aligned on the status band's padding.
+          `flex-1` is desk-only so the footer's `mt-auto` pins the stats line
+          to the viewport bottom at >= 900px and leaves it directly under the
+          summary below that (README §4 states the same width rule). */}
       {!error && (isLoading || article) && (
-        <div className="flex flex-1 flex-col desk:grid desk:grid-cols-[1fr_300px]">
-          {/* Main column */}
-          <article className="flex min-w-0 flex-col gap-5 max-sm:p-5 sm:max-desk:p-8 desk:border-r desk:border-console-line-2 desk:pb-8 desk:pl-9 desk:pr-10 desk:pt-10">
-            <h1 className="text-[22px] font-bold leading-[1.5] sm:text-[36px]">
-              {article ? article.title : '—'}
-            </h1>
+        <article className="flex min-w-0 max-w-[720px] flex-col gap-5 max-sm:p-5 sm:max-desk:p-8 desk:flex-1 desk:px-8 desk:pb-8 desk:pt-10">
+          <h1 className="text-[22px] font-bold leading-[1.5] sm:text-[36px]">
+            {article ? article.title : '—'}
+          </h1>
 
-            <div className="flex flex-wrap items-center gap-[18px] font-mono text-[11.5px]">
-              <span className="border border-console-line-4 px-[9px] py-1 uppercase tracking-[.08em] text-console-cyan">
-                {article ? article.source_name : '—'}
-              </span>
-              <span className="text-console-ink-weak">
-                {formatRelativeTimeJa(article?.published_at)}
-              </span>
-              {originalHref && (
-                <a
-                  href={originalHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-console-ink-sub underline decoration-console-line-4 underline-offset-4 transition-colors duration-[120ms] ease-out hover:decoration-console-ink-sub"
+          <div className="flex flex-wrap items-center gap-[18px] font-mono text-[11.5px]">
+            <span className="border border-console-line-4 px-[9px] py-1 uppercase tracking-[.08em] text-console-cyan">
+              {article ? article.source_name : '—'}
+            </span>
+            <span className="text-console-ink-weak">
+              {formatRelativeTimeJa(article?.published_at)}
+            </span>
+            {originalHref && (
+              <a
+                href={originalHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-console-ink-sub underline decoration-console-line-4 underline-offset-4 transition-colors duration-[120ms] ease-out hover:decoration-console-ink-sub"
+              >
+                原文
+              </a>
+            )}
+          </div>
+
+          <section className="flex flex-col gap-4">
+            <SectionLabel>要約</SectionLabel>
+            {summaryParagraphs.length > 0 ? (
+              summaryParagraphs.map((paragraph, i) => (
+                <p
+                  key={i}
+                  className="text-[15px] leading-[2.1] text-console-ink-sub [text-wrap:pretty]"
                 >
-                  原文
-                </a>
-              )}
-            </div>
-
-            <section className="flex flex-col gap-4">
-              <SectionLabel>要約</SectionLabel>
-              {summaryParagraphs.length > 0 ? (
-                summaryParagraphs.map((paragraph, i) => (
-                  <p
-                    key={i}
-                    className="text-[15px] leading-[2.1] text-console-ink-sub [text-wrap:pretty]"
-                  >
-                    {paragraph}
-                  </p>
-                ))
-              ) : (
-                <p className="font-mono text-[12px] text-console-ink-faint">—</p>
-              )}
-            </section>
-
-            <footer className="mt-auto border-t border-console-line-1 pt-3 font-mono text-[11px] text-console-ink-ghost">
-              本文抽出 — ／ 要約 {article ? article.summary.length : '—'} 字 ／ 取得{' '}
-              {formatClockTime(article?.crawled_at)}
-            </footer>
-          </article>
-
-          {/* Sidebar — script / quiz / same-episode APIs pending */}
-          <aside className="flex flex-col gap-6 border-t border-console-line-2 bg-console-panel max-sm:p-5 sm:max-desk:p-8 desk:border-t-0 desk:px-7 desk:py-10">
-            <section className="flex flex-col gap-3">
-              <SectionLabel>読み上げ台本</SectionLabel>
+                  {paragraph}
+                </p>
+              ))
+            ) : (
               <p className="font-mono text-[12px] text-console-ink-faint">—</p>
-            </section>
+            )}
+          </section>
 
-            <div aria-hidden className="h-px bg-console-line-2" />
-
-            <section className="flex flex-col gap-3">
-              <SectionLabel>出題</SectionLabel>
-              <p className="text-[13.5px] leading-[1.9] text-console-ink-sub">—</p>
-              <div className="flex items-center gap-1.5">
-                {[0, 1, 2].map((i) => (
-                  <span key={i} aria-hidden className="h-[5px] w-6 bg-console-line-3" />
-                ))}
-                <span className="ml-2 font-mono text-[11.5px] text-console-ink-faint">— / —</span>
-              </div>
-              <p className="font-mono text-[11.5px] text-console-violet">— 再出題</p>
-            </section>
-
-            <div aria-hidden className="h-px bg-console-line-2" />
-
-            <section className="flex flex-col gap-3">
-              <SectionLabel>同じ回</SectionLabel>
-              <p className="font-mono text-[12px] text-console-ink-faint">—</p>
-            </section>
-          </aside>
-        </div>
+          <footer className="mt-auto border-t border-console-line-1 pt-3 font-mono text-[11px] text-console-ink-ghost">
+            本文抽出 — ／ 要約 {article ? article.summary.length : '—'} 字 ／ 取得{' '}
+            {formatClockTime(article?.crawled_at)}
+          </footer>
+        </article>
       )}
     </div>
   );

--- a/src/app/(protected)/articles/[id]/page.tsx
+++ b/src/app/(protected)/articles/[id]/page.tsx
@@ -18,16 +18,14 @@ import { safeExternalHref } from '@/lib/utils/safeExternalHref';
  * - 読み上げ台本 / 同じ回 / breadcrumb episode slot ("EP 218 に収録済"): no API
  *   links an article to an episode or its segments (the generated types expose
  *   no `/episodes` path), and adding a backend endpoint just for this screen is
- *   not right-sized. The breadcrumb slot outlived the other two by a day and
- *   was dropped 2026-08-13 to keep the class consistent — the breadcrumb is now
- *   the 記事 link alone.
+ *   not right-sized. The breadcrumb is now the 記事 link alone.
  * - 前後記事: no adjacency API. Faking it with the list's pagination endpoint
  *   would drag the list's filter and sort state into this page — complexity
  *   out of proportion to the value.
  * - 出題: this one was implementable — `GET /learning/items` already returns
  *   `article_id` / `question` / `stage` / `due_on`. It was dropped by product
- *   decision (2026-08-12), not for lack of an API: quizzes belong to
- *   `/learning`, and this page stays a place to read the summary.
+ *   decision, not for lack of an API: quizzes belong to `/learning`, and this
+ *   page stays a place to read the summary.
  *
  * One placeholder is left on purpose: `本文抽出 —` in the footer. The article
  * DTO carries no extracted-body length, but the rest of that line is live data
@@ -71,7 +69,7 @@ export default function ArticleDetailPage() {
       <div className="flex h-[58px] shrink-0 items-center justify-between border-b border-console-line-2 bg-console-band px-5 sm:px-8">
         <Link
           href="/articles"
-          className="flex h-full items-center font-mono text-[11.5px] text-console-ink-weak transition-colors duration-[120ms] ease-out hover:text-console-ink hover:underline"
+          className="flex h-full min-w-[44px] items-center font-mono text-[11.5px] text-console-ink-weak transition-colors duration-[120ms] ease-out hover:text-console-ink hover:underline"
         >
           <span className="sm:hidden">← 記事</span>
           <span className="hidden sm:inline">記事</span>

--- a/src/components/console/ConsoleShell.tsx
+++ b/src/components/console/ConsoleShell.tsx
@@ -142,15 +142,16 @@ export function ConsoleShell({ children }: { children: React.ReactNode }) {
             </React.Fragment>
           ))}
         </nav>
-        {/* Rail footer: host stats need a backend API — degrade to `—` */}
-        <div className="mt-auto border-t border-console-line-2 px-3 pt-3 font-mono text-[10.5px] leading-[2] text-console-ink-weak">
-          <p>PI 5 —</p>
-          <p>MAC —</p>
-          <p>DISK —</p>
+        {/* Rail footer: logout only (the rail's sole sign-out affordance).
+            Host status (PI 5 / MAC / DISK) was removed with D-38 — no host
+            stats API exists, and building one means either a monitoring stack
+            (banned) or a bespoke collector on the Pi. Host liveness is
+            absorbed by 縮退許容, not by a permanent panel here. */}
+        <div className="mt-auto border-t border-console-line-2 px-3 pt-2 font-mono text-[10.5px] leading-[2] text-console-ink-weak">
           <button
             type="button"
             onClick={logout}
-            className="mt-2 flex min-h-[44px] items-center tracking-[.2em] text-console-ink-weak transition-colors duration-[120ms] ease-out hover:text-console-ink"
+            className="flex min-h-[44px] items-center tracking-[.2em] text-console-ink-weak transition-colors duration-[120ms] ease-out hover:text-console-ink"
           >
             ログアウト
           </button>

--- a/tests/e2e/articles/article-detail.spec.ts
+++ b/tests/e2e/articles/article-detail.spec.ts
@@ -8,6 +8,12 @@ test.describe('Article Detail', () => {
 
     await expect(page.getByRole('heading', { name: 'Go 1.25 Released', level: 1 })).toBeVisible();
     await expect(page.getByText(/AI summary for article 25/)).toBeVisible();
+
+    // Regions removed for good by D-38: the episode sidebar panels and the
+    // prev/next navigation. Guards against the `—` stubs creeping back in.
+    await expect(page.getByText(/次の記事/)).toHaveCount(0);
+    await expect(page.getByText('読み上げ台本')).toHaveCount(0);
+    await expect(page.getByText('同じ回')).toHaveCount(0);
   });
 
   test('should link to the original article', async ({ page }) => {
@@ -24,12 +30,12 @@ test.describe('Article Detail', () => {
     await page.getByRole('link', { name: /記事: Go 1\.25 Released/ }).click();
     await expect(page).toHaveURL(/\/articles\/25/);
 
-    // Status-band breadcrumb links back to the list
-    await page
-      .locator('a[href="/articles"]')
-      .filter({ hasText: '記事' })
-      .first()
-      .click();
+    // Status-band breadcrumb links back to the list. Scoped to <main>: the
+    // ConsoleShell rail (<aside>, earlier in the DOM) also links to /articles,
+    // so an unscoped locator would test the rail instead of the breadcrumb.
+    const breadcrumb = page.locator('main a[href="/articles"]');
+    await expect(breadcrumb).toHaveCount(1);
+    await breadcrumb.click();
     await expect(page).toHaveURL(/\/articles(\?|$)/);
   });
 


### PR DESCRIPTION
## 概要

記事詳細ページと左レールから、backend に対応する API が無く恒久的に `—` を表示していたプレースホルダ領域を撤去する。設計判断は `docs/decisions.md` の **D-38** に記録済み。

## 削除した領域

### 記事詳細ページ

| 領域 | 削除理由 |
|---|---|
| 右サイドバー「読み上げ台本」「同じ回」 | 記事とエピソード/セグメントを紐づける API が無い（生成済み型に `/episodes` 系のパスが存在しない） |
| 右サイドバー「出題」 | `GET /learning/items` で**実装は可能**だが、学習系の UI は `/learning` に集約する方針とした |
| ステータス帯「← 前の記事」「次の記事 →」 | 隣接記事を返す API が無い。一覧のページング API で代替すると一覧側の絞り込み・並び順の状態を詳細ページへ引き回す必要があり、得られる価値に対して複雑度が見合わない |
| パンくずのエピソード収録位置 `—` | 「同じ回」と同一クラスの恒久プレースホルダ。片方だけ残すのは一貫しないため撤去 |

### 左レール

`PI 5 —` / `MAC —` / `DISK —` のホスト状態。値を出すには監視基盤の導入か Pi 側での収集の自作が必要で、いずれも単一ユーザー規模に対して過剰。ホストの死活は「壊れても翌日戻る」縮退方針で吸収しているため、ダッシュボードに常設の監視パネルは持たない。ログアウトボタンは残置。

## レイアウトの変更

2 カラム grid（`1fr 300px`）を廃し、`max-width: 720px` の**左寄せ**単一カラムにした。

中央寄せも試したが、タブレット幅でステータス帯のパンくず・見出し・footer 罫線の左端がずれ、放送卓デザインの 1px ヘアライン整列が崩れるため採らなかった。左寄せ + ステータス帯と同じ左パディングにすることで、全幅域で左端が一致する（1440px で 246px の一致を実測）。

footer 統計行の下端固定（`margin-top: auto`）は 900px 以上のみとし、それ未満は本文直後に置く（従来の挙動を維持）。

## ついでに直したもの

- **パンくずリンクのタップ領域**が mono 11.5px の行高（約 17px）しか無く、デザイン仕様の「最小 44px」に反していた。帯の高さいっぱい（57px）に広げた。スマホでは記事一覧への戻り導線にあたるため実利がある
- **e2e のパンくず検証が、実際にはレールのナビ項目を踏んでいた**。`a[href="/articles"]` が `<aside>` 内の要素にもマッチし `.first()` がそちらに解決していたため、`main` 配下に絞り込み `toHaveCount(1)` を添えた

## 残置したプレースホルダ

footer の `本文抽出 —` のみ。記事 DTO が本文長を返さないため値は出ないが、同じ行が要約字数と取得時刻という生きた値を出しているので、1 フィールドを縮退させたまま行ごと残している。

## 設計書の更新（このリポジトリ外）

`design_handoff_catchup_feed_console/README.md` を実装に整合するよう改訂済み（§3 レール最下、§4 の Purpose / ステータス帯 / grid / メタ行 / footer / 右サイド 3 パネル、State Management の `article` `quizLadder`）。

あわせて、§4 に現行 API では実装できない記述（メタ行の要約プロバイダ `GEMINI`、footer の原文字数 `12,480 字`）が残っていたため是正した。記事 DTO は `crawled_at / id / published_at / source_id / source_name / summary / title / url` のみで、provider も本文長も返さない。

## 検証

- `npm run lint`（max-warnings 0）: pass
- `npm run test`: 74 files / 1521 passed, 1 skipped
- `npm run build`: pass
- `npx playwright test`: 59 passed
- 390 / 834 / 1440px でスクリーンショット確認

※ `article-search.spec.ts` のデバウンス待ちが並列実行時に稀にタイムアウトするが、変更前の HEAD でも同頻度で再現する既存の flaky であり、本 PR とは無関係。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified the article reading experience with a focused single-column layout.
  * Removed episode navigation, related-article panels, scripts, and quizzes from article details.
  * Retained article metadata, summaries, original links, and extraction information.
  * Removed placeholder host statistics from the desktop console footer, leaving the logout control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->