### PR TITLE
fix: 概況から API 未提供のプレースホルダ領域を削除(D-39)

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -15,15 +15,20 @@ import type { SourceKind } from '@/types/api';
  * Dashboard (概況) — 放送卓(改訂版) §3
  *
  * Is there enough material for tomorrow's episode, and are the friends still
- * listening? Both panels are backed by a real API: 明朝の候補 (latest crawled
- * articles) and 受信状況 (per-friend last access, C-8).
+ * listening? D-39(2) dropped the older "did this morning's episode go out"
+ * half of that question — the podcast app and the Discord notification answer
+ * it. Both remaining panels are backed by a real API: 明朝の候補 (latest
+ * crawled articles) and 受信状況 (per-friend last access, C-8).
  *
- * The episode / batch / retention panels used to sit here as hairline frames
- * full of permanent `—`, and were removed — a whole panel that never fills in
- * costs a screenful of attention for nothing. That call was scoped to panels
- * only: the metric tiles above still show `—` for their pending fields, kept
- * by explicit instruction because they are one line each and the row already
- * carries a real value (記事).
+ * D-39(1) removed five regions that had displayed a permanent `—` ever since
+ * they were built, none of them having an API behind it: the status band's
+ * left cluster, the 今朝の構成 / 夜間バッチ / 定着 30日 panels, and the bottom
+ * `クイズ在庫 ／ 飽和閾値` `episodes/ ／ 保持` footer.
+ *
+ * The metric tiles below 900px are the one survivor of that sweep. D-39(4)
+ * kept them only because the user's removal list did not name them, and says
+ * so explicitly: EPISODE / 尺 / 要約待ち are the same permanent `—` (記事 is
+ * the sole tile with real data) and are to be reconsidered next cycle.
  */
 
 const KIND_LABELS: Record<SourceKind, string> = {

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -90,7 +90,7 @@ export default function DashboardPage() {
       {/* Status band — desk only: clock + logout. Below desk ConsoleShell's own
           header already carries both, so the band would be an empty strip. */}
       <div className="hidden h-[58px] shrink-0 items-center justify-end border-b border-console-line-2 bg-console-band px-5 sm:px-8 desk:flex">
-        <div className="hidden items-center gap-4 desk:flex">
+        <div className="flex items-center gap-4">
           <ConsoleClock className="text-[11.5px] text-console-ink-weak" />
           <button
             type="button"

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -87,8 +87,9 @@ export default function DashboardPage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      {/* Status band — clock + logout only; episode state has no backend API */}
-      <div className="flex h-[58px] shrink-0 items-center justify-end border-b border-console-line-2 bg-console-band px-5 sm:px-8">
+      {/* Status band — desk only: clock + logout. Below desk ConsoleShell's own
+          header already carries both, so the band would be an empty strip. */}
+      <div className="hidden h-[58px] shrink-0 items-center justify-end border-b border-console-line-2 bg-console-band px-5 sm:px-8 desk:flex">
         <div className="hidden items-center gap-4 desk:flex">
           <ConsoleClock className="text-[11.5px] text-console-ink-weak" />
           <button

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -14,10 +14,12 @@ import type { SourceKind } from '@/types/api';
 /**
  * Dashboard (概況) — 放送卓(改訂版) §3
  *
- * Did this morning's episode go out, and is there enough material for
- * tomorrow? Episode / batch / retention data has no backend API yet, so those
- * panels degrade to hairline frames with `—` (README ローディング spec) —
- * no fabricated values.
+ * Is there enough material for tomorrow's episode, and are the friends still
+ * listening? Only the panels backed by a real API are rendered: 明朝の候補
+ * (latest crawled articles) and 受信状況 (per-friend last access, C-8). The
+ * episode / batch / retention panels were removed rather than kept as hairline
+ * frames full of `—` — no fabricated values, and no frames that never fill in.
+ * The metric tiles keep `—` for the fields whose API is still pending.
  */
 
 const KIND_LABELS: Record<SourceKind, string> = {
@@ -85,13 +87,8 @@ export default function DashboardPage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      {/* Status band — episode state needs a backend API; degrade to `—` */}
-      <div className="flex h-[58px] shrink-0 items-center justify-between border-b border-console-line-2 bg-console-band px-5 sm:px-8">
-        <div className="flex items-center gap-3 font-mono text-[11.5px]">
-          <span aria-hidden className="h-2 w-2 rounded-full bg-console-off" />
-          <span className="tracking-[.2em] text-console-ink-weak">—</span>
-          <span className="text-console-ink-weak">第—号 ／ — JST ／ —</span>
-        </div>
+      {/* Status band — clock + logout only; episode state has no backend API */}
+      <div className="flex h-[58px] shrink-0 items-center justify-end border-b border-console-line-2 bg-console-band px-5 sm:px-8">
         <div className="hidden items-center gap-4 desk:flex">
           <ConsoleClock className="text-[11.5px] text-console-ink-weak" />
           <button
@@ -116,30 +113,6 @@ export default function DashboardPage() {
         <div className="grid flex-1 grid-cols-1 gap-[26px] sm:max-desk:grid-cols-[1.4fr_1fr] desk:grid-cols-[1.55fr_1fr]">
           {/* Left column */}
           <div className="flex min-w-0 flex-col gap-5">
-            {/* 今朝の構成 — episode segments API not available yet */}
-            <section className="border border-console-line-2 bg-console-panel">
-              <header className="flex items-center justify-between border-b border-console-line-1 px-[18px] py-3">
-                <PanelHeading>今朝の構成</PanelHeading>
-                <span className="font-mono text-[11px] text-console-cyan">
-                  — 記事 ／ — 書籍 ／ — 問
-                </span>
-              </header>
-              {[0, 1, 2].map((i) => (
-                <div
-                  key={i}
-                  className={cn(
-                    'flex items-center gap-4 px-[18px] py-3',
-                    i < 2 && 'border-b border-console-line-1'
-                  )}
-                >
-                  <span className="w-[46px] shrink-0 font-mono text-[12px] text-console-cyan">
-                    —
-                  </span>
-                  <span className="min-h-[20px] flex-1" />
-                </div>
-              ))}
-            </section>
-
             {/* 明朝の候補 — latest crawled articles */}
             <section>
               <header className="flex items-center justify-between pb-2">
@@ -193,19 +166,6 @@ export default function DashboardPage() {
 
           {/* Right column */}
           <div className="flex min-w-0 flex-col gap-[18px]">
-            {/* 夜間バッチ — jobs API not available yet */}
-            <section className="border border-console-line-2 bg-console-panel px-[18px] py-4">
-              <PanelHeading>夜間バッチ</PanelHeading>
-              <div className="mt-3 flex flex-col gap-2.5 font-mono text-[12px]">
-                {['書籍取り込み', '文字起こし', '番組生成', '要約系統'].map((label) => (
-                  <div key={label} className="flex items-center justify-between gap-4">
-                    <span className="text-console-ink-sub">{label}</span>
-                    <span className="text-console-cyan">—</span>
-                  </div>
-                ))}
-              </div>
-            </section>
-
             {/* 受信状況 — per-friend last access (real data) */}
             <section className="border border-console-line-2 bg-console-panel px-[18px] py-4">
               <PanelHeading>受信状況</PanelHeading>
@@ -249,21 +209,6 @@ export default function DashboardPage() {
                 </div>
               )}
             </section>
-
-            {/* 定着 30日 — retention API not available yet */}
-            <section className="border border-console-line-2 bg-console-panel px-[18px] py-4">
-              <PanelHeading>定着 30日</PanelHeading>
-              <div className="mt-3 h-[54px]" />
-              <div className="mt-2 flex items-center justify-between font-mono text-[11px]">
-                <span className="text-console-ink-sub">正答率</span>
-                <span className="text-console-ink-weak">— → —</span>
-              </div>
-            </section>
-
-            <div className="mt-auto font-mono text-[11px] leading-[2] text-console-ink-faint">
-              <p>クイズ在庫 — ／ 飽和閾値 —</p>
-              <p>episodes/ — ／ 保持 —</p>
-            </div>
           </div>
         </div>
       </div>

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -15,11 +15,15 @@ import type { SourceKind } from '@/types/api';
  * Dashboard (概況) — 放送卓(改訂版) §3
  *
  * Is there enough material for tomorrow's episode, and are the friends still
- * listening? Only the panels backed by a real API are rendered: 明朝の候補
- * (latest crawled articles) and 受信状況 (per-friend last access, C-8). The
- * episode / batch / retention panels were removed rather than kept as hairline
- * frames full of `—` — no fabricated values, and no frames that never fill in.
- * The metric tiles keep `—` for the fields whose API is still pending.
+ * listening? Both panels are backed by a real API: 明朝の候補 (latest crawled
+ * articles) and 受信状況 (per-friend last access, C-8).
+ *
+ * The episode / batch / retention panels used to sit here as hairline frames
+ * full of permanent `—`, and were removed — a whole panel that never fills in
+ * costs a screenful of attention for nothing. That call was scoped to panels
+ * only: the metric tiles above still show `—` for their pending fields, kept
+ * by explicit instruction because they are one line each and the row already
+ * carries a real value (記事).
  */
 
 const KIND_LABELS: Record<SourceKind, string> = {
@@ -111,7 +115,13 @@ export default function DashboardPage() {
           <MetricTile label="要約待ち" value="—" accent className="border-l" />
         </div>
 
-        <div className="grid flex-1 grid-cols-1 gap-[26px] sm:max-desk:grid-cols-[1.4fr_1fr] desk:grid-cols-[1.55fr_1fr]">
+        {/* `flex-1` is desk-only (same rule as 記事詳細, D-38). At < 640px the
+            two panels stack into two auto rows; stretching the grid to the
+            leftover viewport height would inflate those rows (align-content
+            defaults to stretch) and strand a gap between the panels. Letting
+            the grid stay content-sized below 900px avoids that, and is visually
+            identical at 640–899px where the panels sit side by side. */}
+        <div className="grid grid-cols-1 gap-[26px] sm:max-desk:grid-cols-[1.4fr_1fr] desk:grid-cols-[1.55fr_1fr] desk:flex-1">
           {/* Left column */}
           <div className="flex min-w-0 flex-col gap-5">
             {/* 明朝の候補 — latest crawled articles */}

--- a/tests/e2e/auth/login.spec.ts
+++ b/tests/e2e/auth/login.spec.ts
@@ -46,7 +46,7 @@ test.describe('Login Flow', () => {
     await page.getByRole('button', { name: 'ログイン' }).click();
 
     await expect(page).toHaveURL(/\/dashboard/);
-    await expect(page.getByRole('heading', { name: '今朝の構成' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '明朝の候補' })).toBeVisible();
   });
 
   test('should stay unauthenticated on invalid credentials', async ({ page }) => {

--- a/tests/e2e/auth/logout.spec.ts
+++ b/tests/e2e/auth/logout.spec.ts
@@ -4,7 +4,7 @@ import { AUTH_TOKEN_KEY } from '../support/auth';
 test.describe('Logout Flow', () => {
   test('should logout and clear session data', async ({ page, authenticated: _auth }) => {
     await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: '今朝の構成' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '明朝の候補' })).toBeVisible();
 
     await page.getByRole('button', { name: 'ログアウト' }).first().click();
 

--- a/tests/e2e/dashboard/dashboard.spec.ts
+++ b/tests/e2e/dashboard/dashboard.spec.ts
@@ -8,9 +8,8 @@ test.describe('Dashboard', () => {
   });
 
   test('should display statistics from the API', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: '今朝の構成' })).toBeVisible();
-
     // 明朝の候補 links to the full article list with the total count
+    await expect(page.getByRole('heading', { name: '明朝の候補' })).toBeVisible();
     await expect(
       page.getByRole('link', { name: `${ARTICLE_COUNT} 件すべて見る` })
     ).toBeVisible();

--- a/tests/e2e/dashboard/layout.spec.ts
+++ b/tests/e2e/dashboard/layout.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../support/test';
+
+/**
+ * Viewport-dependent layout regressions on 概況.
+ *
+ * `flex-1` on a container that stretches to the viewport has produced the same
+ * regression twice: D-38 (記事詳細 footer) and D-39 (this grid — dropping to
+ * two panels made the grid two auto rows, which `align-content: stretch` then
+ * inflated, stranding ~123px between 明朝の候補 and 受信状況 at 390px). Both
+ * fixes were "make `flex-1` desk-only", and neither regression was caught by a
+ * test: no other e2e in this repo sets a viewport, so nothing exercised the
+ * < 640px single-column path that the user actually reads on their phone.
+ *
+ * This spec closes that gap. It asserts the panels are separated by the grid's
+ * own `gap-[26px]` and nothing more — a stretched row shows up here as a gap
+ * several times too large.
+ */
+
+/** The 本文 grid's `gap-[26px]`; the only space that belongs between panels. */
+const PANEL_GAP_PX = 26;
+
+/** iPhone 14/15 logical viewport — the primary reading device (CLAUDE.md). */
+const PHONE = { width: 390, height: 844 };
+
+test.describe('Dashboard layout', () => {
+  test('separates the stacked panels by exactly the grid gap at 390px', async ({
+    page,
+    authenticated: _auth,
+  }) => {
+    await page.setViewportSize(PHONE);
+    await page.goto('/dashboard');
+
+    const upcoming = page
+      .locator('section')
+      .filter({ has: page.getByRole('heading', { name: '明朝の候補' }) });
+    const reception = page
+      .locator('section')
+      .filter({ has: page.getByRole('heading', { name: '受信状況' }) });
+
+    await expect(upcoming).toBeVisible();
+    await expect(reception).toBeVisible();
+
+    const upcomingBox = await upcoming.boundingBox();
+    const receptionBox = await reception.boundingBox();
+    expect(upcomingBox).not.toBeNull();
+    expect(receptionBox).not.toBeNull();
+
+    // Single column at this width, so 受信状況 sits below 明朝の候補.
+    expect(receptionBox!.y).toBeGreaterThan(upcomingBox!.y);
+
+    const gap = receptionBox!.y - (upcomingBox!.y + upcomingBox!.height);
+    // Precision 0 = within half a pixel, so sub-pixel layout rounding cannot
+    // flake the test while a stretched row (was 122.88px) still fails loudly.
+    expect(gap).toBeCloseTo(PANEL_GAP_PX, 0);
+  });
+
+  test('keeps the panels side by side at 1440px', async ({ page, authenticated: _auth }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+
+    const upcoming = page
+      .locator('section')
+      .filter({ has: page.getByRole('heading', { name: '明朝の候補' }) });
+    const reception = page
+      .locator('section')
+      .filter({ has: page.getByRole('heading', { name: '受信状況' }) });
+
+    const upcomingBox = await upcoming.boundingBox();
+    const receptionBox = await reception.boundingBox();
+    expect(upcomingBox).not.toBeNull();
+    expect(receptionBox).not.toBeNull();
+
+    // Two columns: the panels share a top edge instead of stacking. This is
+    // the half `desk:flex-1` must not change.
+    expect(receptionBox!.y).toBeCloseTo(upcomingBox!.y, 0);
+    expect(receptionBox!.x).toBeGreaterThan(upcomingBox!.x + upcomingBox!.width);
+  });
+});


### PR DESCRIPTION
## 概要

概況(ダッシュボード)から、backend API が無いまま恒久的に `—` を表示し続けていた5領域を削除する。D-35(記事詳細の音声プレイヤー) → D-38(記事詳細の右サイドバー・左レールのホスト状態)と続いた是正の3件目。

決定は `docs/decisions.md` の **D-39** に記録済み。design_handoff README §3 / §Responsive / State Management も同時に改訂した。

## 削除したもの

| 領域 | 削除理由 |
|---|---|
| ステータス帯左の `送出済 ／ 第—号 ／ — JST ／ —` | エピソードを返す API が無い |
| **今朝の構成** パネル | エピソードのセグメントを返す API が無い |
| **夜間バッチ** パネル | `jobs` を公開する API が無い |
| **定着 30日** パネル | 正答率の時系列を返す API が無い |
| 最下の脚注 `クイズ在庫 ／ 飽和閾値` `episodes/ ／ 保持` | 在庫・ディスク使用量とも API が無い |

Purpose も「今朝の号が無事に出たか、明朝の材料が足りているか」から前半を落とした。配信の成否はポッドキャストアプリと Discord 通知で分かるため、この確認動線は概況に置かない(D-39(2))。

## 併せて対応した2点

**1. スマホ・タブレット幅でステータス帯を描画しない(`69bf20a`)**

帯の右(時計 + ログアウト)は元から `desk:flex` で、左を削ると `< 900px` では空の 58px 帯だけが残る。`ConsoleShell` のモバイルヘッダ(`desk:hidden`、同じ `bg-console-band`)が時計とログアウトを既に提供しているため、同色の帯が2本重なる死に帯になっていた。情報の欠落はない。

**2. スマホ幅のレイアウト回帰を修正(`5be837d`)**

パネルが各カラム1枚に減ったことで、本文 grid の `flex-1` が `align-content: stretch` により auto 行を引き伸ばし、390px で本文中央に約 123px の空白が生じていた。D-38 で記事詳細 footer に適用した `desk:flex-1` と同じ形に揃えて解消。

| 390×844 | 修正前 | 修正後 |
|---|---|---|
| `grid-template-rows` | 269.125px / 284.375px | 172.25px / 187.5px |
| パネル間の空白 | 122.88px | 26px (`gap-[26px]` のみ) |
| 最終パネル下端〜grid 下端 | 96.88px | 0px |

`>= 900px` は `flex-1` と `desk:flex-1` が同一宣言を出すため構造上完全一致(1440 実測で確認)。

## 再発防止

`flex-1` の効き過ぎによるレイアウト回帰は D-38(記事詳細 footer)と今回で2回目。リポジトリにビューポート依存の e2e が1本も無かったため、`tests/e2e/dashboard/layout.spec.ts` を新設した(`2f5b6c6`)。390px でパネル間余白が 26px ちょうどであること、1440px で横並びが維持されることを検証する。

**回帰を実際に捕まえることを確認済み**: `desk:flex-1` を `flex-1` に戻すと `Expected: 26 / Received: 122.875` で落ちる。

## 残置したもの

指標タイル(`< 900px` のみ表示)は削除対象に含まれなかったため残置。ただし `EPISODE` `尺` `要約待ち` の3枚は上記と同一クラスの恒久 `—` で、実データがあるのは `記事` のみ。スマホ幅(`< 640px`)では `記事` と `要約待ち` の2枚だけが出るため、見えるうち1枚が恒久 `—` になる。D-39(4) で次サイクルの再検討対象として保留した。

## 検証

- `npm run lint`(max-warnings 0) / `npm run test`(74 files, 1521 passed) / `npm run build` / `npm run format:check` すべて pass
- `npx playwright test` 61 passed(新規2本を含む)
- 360 / 390 / 500 / 639 / 640 / 700 / 768 / 833 / 834 / 898 / 899 / 900 / 901 / 1024 / 1280 / 1440 の16幅で実測し、640px・900px の境界に取りこぼし幅・重複幅がないことを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the dashboard to highlight “明朝の候補” and retain article candidates and friend access status.
  * Removed unavailable placeholder panels and footer content.
  * Improved responsive layout behavior across mobile and desktop screen sizes.
  * Kept status controls, including the clock and logout actions, available on desktop.

* **Tests**
  * Updated login, logout, and dashboard checks to reflect the revised dashboard heading.
  * Added coverage for responsive panel spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->