### PR TITLE
docs(legacy): アーカイブ文書のローカル絶対パスをマスクする

### DIFF
--- a/docs/legacy/architecture.md
+++ b/docs/legacy/architecture.md
@@ -1267,4 +1267,4 @@ catchup-feed-frontend/
 
 **Document Maintained By**: Development Team
 **Review Cycle**: Quarterly or on major architectural changes
-**Questions?**: See [repository-structure.md](/Users/yujitsuchiya/catchup-feed-frontend/docs/repository-structure.md) for file organization details.
+**Questions?**: See [repository-structure.md](./repository-structure.md) for file organization details.

--- a/docs/legacy/glossary.md
+++ b/docs/legacy/glossary.md
@@ -1022,11 +1022,11 @@ Google's metrics for web performance.
 
 ## Related Documentation
 
-- [Product Requirements](/Users/yujitsuchiya/catchup-feed-frontend/docs/product-requirements.md)
-- [Functional Design](/Users/yujitsuchiya/catchup-feed-frontend/docs/functional-design.md)
-- [Architecture](/Users/yujitsuchiya/catchup-feed-frontend/docs/architecture.md)
-- [Repository Structure](/Users/yujitsuchiya/catchup-feed-frontend/docs/repository-structure.md)
-- [Development Guidelines](/Users/yujitsuchiya/catchup-feed-frontend/docs/development-guidelines.md)
+- [Product Requirements](./product-requirements.md)
+- [Functional Design](./functional-design.md)
+- [Architecture](./architecture.md)
+- [Repository Structure](./repository-structure.md)
+- [Development Guidelines](./development-guidelines.md)
 
 ---
 

--- a/docs/legacy/product-requirements.md
+++ b/docs/legacy/product-requirements.md
@@ -1444,4 +1444,4 @@ interface PaginationMetadata {
 **Document History**:
 - 2026-01-05: Initial version created based on codebase analysis
 - 2026-01-10: Updated for Next.js 16.1.1, React 19.2.3, and @serwist/next PWA migration
-- Generated from actual source code in /Users/yujitsuchiya/catchup-feed-frontend
+- Generated from actual source code in path/to/catchup-feed-frontend


### PR DESCRIPTION
## 背景

backend 側 D-44 のレビュー中に、code-reviewer が横断検索で検出したもの。`docs/legacy/` 配下の3ファイルに、開発マシンの macOS ローカル絶対パス(ユーザー名とディレクトリ構成を含む)が残っていた。

このリポジトリは **GitHub PUBLIC**。API キーや DSN のような資格情報ではないが、開発マシンのユーザー名とディレクトリ構成が公開されている状態であり、親 `CLAUDE.md` の公開リポジトリ衛生(実ホスト名・秘密情報をコミットしない)と同じクラスの問題として扱う。

ユーザー裁定は「**絶対パスだけマスクする**」。`docs/legacy/` ごと削除する案も検討されたが、履歴価値を保つため不採用。

## 走査結果

`git grep -n "/Users/"` でリポジトリ全体を走査した。報告されていた3ファイル **7箇所** がすべてで、それ以外の文書への混入は無し。

| ファイル | 件数 |
|---|---|
| `docs/legacy/glossary.md` | 5 |
| `docs/legacy/architecture.md` | 1 |
| `docs/legacy/product-requirements.md` | 1 |

## 置き換え内容

### 1. `glossary.md`(5件)/ `architecture.md`(1件)— relative link へ

いずれも markdown のリンク先が絶対パスになっていたもの。**同ディレクトリの `docs/legacy/repository-structure.md` が、まったく同じ "Related Documentation" セクションで既に `./foo.md` 記法を使っている**ため、新しい記法を発明せずそれに合わせた。

リンク先5本(`product-requirements` / `functional-design` / `architecture` / `repository-structure` / `development-guidelines`)はすべて `docs/legacy/` 配下に実在するため、リンクとしても正しく解決する。むしろ絶対パスのままでは開発者本人の環境以外で解決できないリンクだったので、マスクと同時に実質的な修正になっている。

### 2. `product-requirements.md`(1件)— `path/to/` へ

`Generated from actual source code in ...` という散文で、**リポジトリのチェックアウト先**を指していた(ホーム配下の別リソースではない)。リンクではないため relative link 化はできない。

対象3ファイルはいずれも日本語を1行も含まない完全な英語文書であるため、`<リポジトリのルート>` は文体上そぐわないと判断し、英語文書で慣用的かつ「各自の環境に読み替える」ことが自明な `path/to/` を採用した。リポジトリ名自体は公開情報(リポジトリ名そのもの)なので残している。

## 残存する `/Users/` について

置き換え後、`git grep -n "/Users/"` に残るのは以下2箇所のみ:

- `src/components/books/BookCard.stories.tsx:84`
- `src/components/books/BookCard.test.tsx:23`

いずれも「CLI 取り込み書籍(Pi 側にあってダッシュボードから削除できない)」を表す **Storybook / テストのモックデータ**の `file_path` であり、実在するパスではない。ユーザー名部分も開発マシンの実ユーザー名とは異なる短い架空名で、実環境の情報を漏らしていない。加えて本タスクの制約が「ドキュメントのみ・`src/` 配下に触れないこと」であるため、意図的に変更していない。

## テスト

**ドキュメント(markdown)のみの変更のため、ビルド・テストは実行していない。** 変更した3ファイルは `docs/legacy/` 配下の markdown で、`src/` および `next.config` / `package.json` のいずれからも参照されておらず(確認済み)、Next.js のビルド入力に含まれない。したがって lint / vitest / e2e / build の結果に影響し得ない。

## design_handoff README の改訂要否

**不要**。画面の寸法・色・レスポンシブ規定には一切触れていない。

## backend API への追加要望

**なし**。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated legacy documentation links to use repository-relative paths.
  * Replaced outdated local filesystem references with portable generic paths.
  * Improved documentation portability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->